### PR TITLE
Graceful shutdown

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,9 +1,11 @@
-[test-groups]
+# https://nexte.st/book/configuration.html
+
+[test-groups.serial-integration]
 # Run integration tests serially.
 # We only apply this setting in the `ci` profile; the CI builders are small
 # enough that running multiple integration tests at the same time actually
 # makes the entire test suite complete slower.
-serial-integration = { max-threads = 1 }
+max-threads = 1
 
 [profile.ci]
 # Print out output for failing tests as soon as they fail, and also at the end
@@ -11,6 +13,11 @@ serial-integration = { max-threads = 1 }
 failure-output = "immediate-final"
 # Do not cancel the test run on the first failure.
 fail-fast = false
+# The Garnix CI builders run in some weird virtual filesystem that messes with
+# `notify`. Even with sleeps before writing and poll-based notifications,
+# sometimes `notify` misses events (this is rare, maybe 1 in 50 test runs).
+# Retry tests if they fail in CI to mitigate this.
+retries = 3
 
 [[profile.ci.overrides]]
 # `kind(test)` means integration tests in the `../tests/` directory.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -71,45 +71,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
-
-[[package]]
-name = "async-priority-channel"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c21678992e1b21bebfe2bc53ab5f5f68c106eddab31b24e0bb06e9b715a86640"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
-name = "async-recursion"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.29",
-]
-
-[[package]]
-name = "async-trait"
-version = "0.1.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.29",
-]
-
-[[package]]
-name = "atomic-take"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8ab6b55fe97976e46f91ddbed8d147d966475dc29b2032757ba47e02376fbc3"
 
 [[package]]
 name = "atty"
@@ -174,26 +137,6 @@ name = "bitflags"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
-
-[[package]]
-name = "bstr"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
-dependencies = [
- "memchr",
- "regex-automata 0.3.7",
- "serde",
-]
-
-[[package]]
-name = "btoi"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "bytes"
@@ -265,35 +208,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
-name = "clearscreen"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f3f22f1a586604e62efd23f78218f3ccdecf7a33c4500db2d37d85a24fe994"
-dependencies = [
- "nix",
- "terminfo",
- "thiserror",
- "which",
- "winapi",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
-
-[[package]]
-name = "command-group"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5080df6b0f0ecb76cab30808f00d937ba725cebe266a3da8cd89dff92f2a9916"
-dependencies = [
- "async-trait",
- "nix",
- "tokio",
- "winapi",
-]
 
 [[package]]
 name = "crossbeam-channel"
@@ -327,48 +245,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
-name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "dissimilar"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86e3bdc80eee6e16b2b6b0f87fbc98c04bee3455e35174c0de1a125d0688c632"
 
 [[package]]
-name = "dunce"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
-
-[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
-
-[[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "errno"
@@ -378,7 +264,7 @@ checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -390,12 +276,6 @@ dependencies = [
  "cc",
  "libc",
 ]
-
-[[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "expect-test"
@@ -414,6 +294,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
+name = "file-id"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6584280525fb2059cba3db2c04abf947a1a29a45ddae89f3870f8281704fafc9"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,15 +310,9 @@ checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.3.5",
- "windows-sys 0.48.0",
+ "redox_syscall",
+ "windows-sys",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fs_extra"
@@ -447,52 +330,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-macro"
@@ -506,12 +347,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-sink"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
-
-[[package]]
 name = "futures-task"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,13 +358,9 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -561,6 +392,7 @@ dependencies = [
  "line-span",
  "miette",
  "nix",
+ "notify-debouncer-full",
  "once_cell",
  "owo-colors",
  "path-absolutize",
@@ -576,8 +408,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
- "watchexec",
- "watchexec-signals",
  "winnow",
 ]
 
@@ -586,236 +416,6 @@ name = "gimli"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
-
-[[package]]
-name = "gix-actor"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848efa0f1210cea8638f95691c82a46f98a74b9e3524f01d4955ebc25a8f84f3"
-dependencies = [
- "bstr",
- "btoi",
- "gix-date",
- "itoa",
- "nom",
- "thiserror",
-]
-
-[[package]]
-name = "gix-config"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d252a0eddb6df74600d3d8872dc9fe98835a7da43110411d705b682f49d4ac1"
-dependencies = [
- "bstr",
- "gix-config-value",
- "gix-features",
- "gix-glob",
- "gix-path",
- "gix-ref",
- "gix-sec",
- "log",
- "memchr",
- "nom",
- "once_cell",
- "smallvec",
- "thiserror",
- "unicode-bom",
-]
-
-[[package]]
-name = "gix-config-value"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e874f41437441c02991dcea76990b9058fadfc54b02ab4dd06ab2218af43897"
-dependencies = [
- "bitflags 2.4.0",
- "bstr",
- "gix-path",
- "libc",
- "thiserror",
-]
-
-[[package]]
-name = "gix-date"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc164145670e9130a60a21670d9b6f0f4f8de04e5dd256c51fa5a0340c625902"
-dependencies = [
- "bstr",
- "itoa",
- "thiserror",
- "time",
-]
-
-[[package]]
-name = "gix-features"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf69b0f5c701cc3ae22d3204b671907668f6437ca88862d355eaf9bc47a4f897"
-dependencies = [
- "gix-hash",
- "libc",
- "sha1_smol",
- "walkdir",
-]
-
-[[package]]
-name = "gix-fs"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b37a1832f691fdc09910bd267f9a2e413737c1f9ec68c6e31f9e802616278a9"
-dependencies = [
- "gix-features",
-]
-
-[[package]]
-name = "gix-glob"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c07c98204529ac3f24b34754540a852593d2a4c7349008df389240266627a72a"
-dependencies = [
- "bitflags 2.4.0",
- "bstr",
- "gix-features",
- "gix-path",
-]
-
-[[package]]
-name = "gix-hash"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b422ff2ad9a0628baaad6da468cf05385bf3f5ab495ad5a33cce99b9f41092f"
-dependencies = [
- "hex",
- "thiserror",
-]
-
-[[package]]
-name = "gix-lock"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c693d7f05730fa74a7c467150adc7cea393518410c65f0672f80226b8111555"
-dependencies = [
- "gix-tempfile",
- "gix-utils",
- "thiserror",
-]
-
-[[package]]
-name = "gix-object"
-version = "0.29.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d96bd620fd08accdd37f70b2183cfa0b001b4f1c6ade8b7f6e15cb3d9e261ce"
-dependencies = [
- "bstr",
- "btoi",
- "gix-actor",
- "gix-features",
- "gix-hash",
- "gix-validate",
- "hex",
- "itoa",
- "nom",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "gix-path"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18609c8cbec8508ea97c64938c33cd305b75dfc04a78d0c3b78b8b3fd618a77c"
-dependencies = [
- "bstr",
- "gix-trace",
- "home",
- "once_cell",
- "thiserror",
-]
-
-[[package]]
-name = "gix-ref"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e03989e9d49954368e1b526578230fc7189d1634acdfbe79e9ba1de717e15d5"
-dependencies = [
- "gix-actor",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-lock",
- "gix-object",
- "gix-path",
- "gix-tempfile",
- "gix-validate",
- "memmap2",
- "nom",
- "thiserror",
-]
-
-[[package]]
-name = "gix-sec"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9615cbd6b456898aeb942cd75e5810c382fbfc48dbbff2fa23ebd2d33dcbe9c7"
-dependencies = [
- "bitflags 2.4.0",
- "gix-path",
- "libc",
- "windows",
-]
-
-[[package]]
-name = "gix-tempfile"
-version = "5.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71a0d32f34e71e86586124225caefd78dabc605d0486de580d717653addf182"
-dependencies = [
- "gix-fs",
- "libc",
- "once_cell",
- "parking_lot",
- "tempfile",
-]
-
-[[package]]
-name = "gix-trace"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b6d623a1152c3facb79067d6e2ecdae48130030cf27d6eb21109f13bd7b836"
-
-[[package]]
-name = "gix-utils"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b85d89dc728613e26e0ed952a19583744e7f5240fcd4aa30d6c824ffd8b52f0f"
-dependencies = [
- "fastrand",
-]
-
-[[package]]
-name = "gix-validate"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba9b3737b2cef3dcd014633485f0034b0f1a931ee54aeb7d8f87f177f3c89040"
-dependencies = [
- "bstr",
- "thiserror",
-]
-
-[[package]]
-name = "globset"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
-dependencies = [
- "aho-corasick",
- "bstr",
- "fnv",
- "log",
- "regex",
-]
 
 [[package]]
 name = "heck"
@@ -839,60 +439,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "home"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
-dependencies = [
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "ignore"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
-dependencies = [
- "globset",
- "lazy_static",
- "log",
- "memchr",
- "regex",
- "same-file",
- "thread_local",
- "walkdir",
- "winapi-util",
-]
-
-[[package]]
-name = "ignore-files"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a4d73056a8d335492938cabeef794f38968ef43e6db9bc946638cfd6281003b"
-dependencies = [
- "dunce",
- "futures",
- "gix-config",
- "ignore",
- "miette",
- "project-origins",
- "radix_trie",
- "thiserror",
- "tokio",
- "tracing",
-]
 
 [[package]]
 name = "indoc"
@@ -937,7 +487,7 @@ checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.2",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -948,7 +498,7 @@ checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.2",
  "rustix 0.38.10",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1054,24 +604,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76fc44e2588d5b436dbc3c6cf62aef290f90dab6235744a93dfe1cc18f451e2c"
 
 [[package]]
-name = "memmap2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "miette"
 version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,12 +636,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,16 +653,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1148,42 +665,39 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
- "pin-utils",
 ]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
-name = "normalize-path"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5438dd2b2ff4c6df6e1ce22d825ed2fa93ee2922235cc45186991717f0a892d"
 
 [[package]]
 name = "notify"
-version = "5.2.0"
+version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729f63e1ca555a43fe3efa4f3efdf4801c479da85b432242a7b726f353c88486"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
+ "log",
  "mio",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-sys",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f5dab59c348b9b50cf7f261960a20e389feb2713636399cd9082cd4b536154"
+dependencies = [
+ "crossbeam-channel",
+ "file-id",
+ "log",
+ "notify",
+ "parking_lot",
+ "walkdir",
 ]
 
 [[package]]
@@ -1197,30 +711,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi 0.3.2",
- "libc",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
  "libc",
 ]
 
@@ -1272,9 +768,9 @@ checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1302,44 +798,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 dependencies = [
  "camino",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
-dependencies = [
- "phf_shared",
- "rand",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -1380,33 +838,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "project-origins"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629e0d57f265ca8238345cb616eea8847b8ecb86b5d97d155be2c8963a314379"
-dependencies = [
- "futures",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
 ]
 
 [[package]]
@@ -1441,31 +878,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom",
- "redox_syscall 0.2.16",
- "thiserror",
 ]
 
 [[package]]
@@ -1529,7 +946,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1542,7 +959,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.5",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1598,12 +1015,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1_smol"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1626,12 +1037,6 @@ checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"
@@ -1661,7 +1066,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1753,9 +1158,9 @@ checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "rustix 0.38.10",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1775,20 +1180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
 dependencies = [
  "rustix 0.37.23",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "terminfo"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666cd3a6681775d22b200409aad3b089c5b99fb11ecdd8a204d9d62f8148498f"
-dependencies = [
- "dirs",
- "fnv",
- "nom",
- "phf",
- "phf_codegen",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1886,8 +1278,6 @@ checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
 dependencies = [
  "deranged",
  "itoa",
- "libc",
- "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -1925,7 +1315,7 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "tracing",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1940,24 +1330,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-stream"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tracing"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2051,12 +1429,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bom"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98e90c70c9f0d4d1ee6d0a7d04aa06cb9bbd53d8cfbdd62a0269a7c2eb640552"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,65 +1495,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "watchexec"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b97d05a9305a9aa6a7bedef64cd012ebc9b6f1f5ed0368fb48f0fe58f96988"
-dependencies = [
- "async-priority-channel",
- "async-recursion",
- "atomic-take",
- "clearscreen",
- "command-group",
- "futures",
- "ignore-files",
- "miette",
- "nix",
- "normalize-path",
- "notify",
- "once_cell",
- "project-origins",
- "thiserror",
- "tokio",
- "tracing",
- "watchexec-events",
- "watchexec-signals",
-]
-
-[[package]]
-name = "watchexec-events"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01603bbe02fd75918f010dadad456d47eda14fb8fdcab276b0b4b8362f142ae3"
-dependencies = [
- "nix",
- "notify",
- "watchexec-signals",
-]
-
-[[package]]
-name = "watchexec-signals"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2a5df96c388901c94ca04055fcd51d4196ca3e971c5e805bd4a4b61dd6a7e5"
-dependencies = [
- "miette",
- "nix",
- "thiserror",
-]
-
-[[package]]
-name = "which"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
-dependencies = [
- "either",
- "libc",
- "once_cell",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2213,45 +1526,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2260,20 +1540,14 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2283,21 +1557,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2307,21 +1569,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2331,21 +1581,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +223,18 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "command-group"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5080df6b0f0ecb76cab30808f00d937ba725cebe266a3da8cd89dff92f2a9916"
+dependencies = [
+ "async-trait",
+ "nix",
+ "tokio",
+ "winapi",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -385,6 +408,7 @@ dependencies = [
  "backoff",
  "camino",
  "clap",
+ "command-group",
  "expect-test",
  "humantime",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ readme = "README.md"
 homepage = "https://github.com/MercuryTechnologies/ghciwatch"
 repository = "https://github.com/MercuryTechnologies/ghciwatch"
 license = "MIT"
-keywords = ["haskell", "ghci", "watchexec"]
+keywords = ["haskell", "ghci", "compile", "watch", "notify"]
 categories = ["command-line-utilities", "development-tools"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -41,7 +41,8 @@ humantime = "2.1.0"
 itertools = "0.11.0"
 line-span = "0.1.5"
 miette = { version = "5.9.0", features = ["fancy"] }
-nix = { version = "0.26.2", default_features = false, features = ["process"] }
+nix = { version = "0.26.2", default_features = false, features = ["process", "signal"] }
+notify-debouncer-full = "0.3.1"
 once_cell = "1.18.0"
 owo-colors = { version = "3.5.0", features = ["supports-colors"] }
 path-absolutize = "3.1.1"
@@ -54,8 +55,6 @@ textwrap = { version = "0.16.0", features = ["terminal_size"] }
 tokio = { version = "1.28.2", features = ["full", "tracing"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "time", "json", "registry"] }
-watchexec = "2.3.0"
-watchexec-signals = "1.0.0"
 winnow = "0.5.15"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ aho-corasick = "1.0.2"
 backoff = { version = "0.4.0", default-features = false }
 camino = "1.1.4"
 clap = { version = "4.3.2", features = ["derive", "wrap_help", "env"] }
+command-group = { version = "2.1.0", features = ["tokio", "with-tokio"] }
 humantime = "2.1.0"
 itertools = "0.11.0"
 line-span = "0.1.5"

--- a/README.md
+++ b/README.md
@@ -27,14 +27,16 @@ Rust makes it easy to ship static binaries. Rust also shares many features with
 Haskell: a [Hindley-Milner type system][hm] with inference, pattern matching,
 and immutability by default. Rust can also [interoperate with
 Haskell][hs-bindgen], so in the future we'll be able to ship `ghciwatch` as a
-Hackage package natively. Finally, Rust is home to the excellent cross-platform
-and battle-tested [`watchexec`][watchexec] library, used to implement the
-`watchexec` binary and `cargo-watch`, which solves a lot of the thorny problems
-of watching files for us.
+Hackage package natively. Also, Rust's commitment to stability makes coping
+with multiple GHC versions and GHC upgrades easy. Finally, Rust is home to the
+excellent cross-platform and battle-tested [`notify`][notify] library, used to
+implement the [`watchexec`][watchexec] binary and `cargo-watch`, which solves a
+lot of the thorny problems of watching files for us.
 
 [hm]: https://en.wikipedia.org/wiki/Hindley%E2%80%93Milner_type_system
 [hs-bindgen]: https://engineering.iog.io/2023-01-26-hs-bindgen-introduction/
 [watchexec]: https://github.com/watchexec/watchexec
+[notify]: https://docs.rs/notify/latest/notify/
 
 
 ## Why not just use `watchexec` or similar?

--- a/src/command_ext.rs
+++ b/src/command_ext.rs
@@ -1,9 +1,23 @@
+use std::process::Child as StdChild;
 use std::process::Command as StdCommand;
 
+use miette::Context;
+use miette::IntoDiagnostic;
+use nix::sys::signal::pthread_sigmask;
+use nix::sys::signal::SigSet;
+use nix::sys::signal::SigmaskHow;
+use nix::sys::signal::Signal;
+use tokio::process::Child;
 use tokio::process::Command;
 
 /// Extension trait for commands.
 pub trait CommandExt {
+    /// The type of spawned processes.
+    type Child;
+
+    /// Spawn the command, but do not inherit `SIGINT` signals from the calling process.
+    fn spawn_without_inheriting_sigint(&mut self) -> miette::Result<Self::Child>;
+
     /// Display the command as a string, suitable for user output.
     ///
     /// Arguments and program names should be quoted with [`shell_words::quote`].
@@ -11,12 +25,32 @@ pub trait CommandExt {
 }
 
 impl CommandExt for Command {
+    type Child = Child;
+
+    fn spawn_without_inheriting_sigint(&mut self) -> miette::Result<Self::Child> {
+        spawn_without_inheriting_sigint(|| {
+            self.spawn()
+                .into_diagnostic()
+                .wrap_err_with(|| format!("Failed to start `{}`", self.display()))
+        })
+    }
+
     fn display(&self) -> String {
         self.as_std().display()
     }
 }
 
 impl CommandExt for StdCommand {
+    type Child = StdChild;
+
+    fn spawn_without_inheriting_sigint(&mut self) -> miette::Result<Self::Child> {
+        spawn_without_inheriting_sigint(|| {
+            self.spawn()
+                .into_diagnostic()
+                .wrap_err_with(|| format!("Failed to start `{}`", self.display()))
+        })
+    }
+
     fn display(&self) -> String {
         let program = self.get_program().to_string_lossy();
 
@@ -26,4 +60,23 @@ impl CommandExt for StdCommand {
 
         shell_words::join(tokens)
     }
+}
+
+fn spawn_without_inheriting_sigint<T>(
+    spawn: impl FnOnce() -> miette::Result<T>,
+) -> miette::Result<T> {
+    // See: https://github.com/rust-lang/rust/pull/100737#issuecomment-1445257548
+    let mut old_signal_mask = SigSet::empty();
+    pthread_sigmask(
+        SigmaskHow::SIG_SETMASK,
+        Some(&SigSet::from_iter(std::iter::once(Signal::SIGINT))),
+        Some(&mut old_signal_mask),
+    )
+    .into_diagnostic()?;
+
+    let result = spawn();
+
+    pthread_sigmask(SigmaskHow::SIG_SETMASK, Some(&old_signal_mask), None).into_diagnostic()?;
+
+    result
 }

--- a/src/event_filter.rs
+++ b/src/event_filter.rs
@@ -1,74 +1,16 @@
-//! Parsing [`watchexec::event::Event`]s into changes `ghciwatch` can respond to.
-
-use std::collections::HashMap;
+//! Parsing [`DebouncedEvent`]s into changes `ghciwatch` can respond to.
 
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use miette::IntoDiagnostic;
-use watchexec::action::Action;
-use watchexec::event::filekind::FileEventKind;
-use watchexec::event::filekind::ModifyKind;
-use watchexec::event::Event;
-use watchexec::event::Tag;
+use notify_debouncer_full::notify::EventKind;
+use notify_debouncer_full::DebouncedEvent;
 
-/*
-
-# Notes on reacting to file events
-
-- All file events are tagged `Source(Filesystem)`.
-- `file_type` is `None` for temporary files used as buffers for atomic writes, like `src/4913` or `src/App.hs~`
-  ...or in general, files that are removed?
-
-  Looks like it's populated by the metadata for the path:
-  https://github.com/watchexec/watchexec/blob/402d1ba4f900b5e744e33d56b824e92833d60613/crates/lib/src/fs.rs#L314
-
-Events when I write an existing source file in vim:
-• FileEventKind(Modify(Name(Any))),           "/Users/wiggles/mwb4/src/App.hs",  file_type: Some(File)
-• FileEventKind(Create(File)),                "/Users/wiggles/mwb4/src/App.hs",  file_type: Some(File)
-• FileEventKind(Modify(Data(Content))),       "/Users/wiggles/mwb4/src/App.hs",  file_type: Some(File)
-• FileEventKind(Modify(Metadata(Ownership))), "/Users/wiggles/mwb4/src/App.hs",  file_type: Some(File)
-• FileEventKind(Modify(Name(Any))),           "/Users/wiggles/mwb4/src/App.hs~", file_type: None
-• FileEventKind(Remove(File)),                "/Users/wiggles/mwb4/src/App.hs~", file_type: None
-• FileEventKind(Create(File)),                "/Users/wiggles/mwb4/src/4913",    file_type: None
-• FileEventKind(Remove(File)),                "/Users/wiggles/mwb4/src/4913",    file_type: None
-• FileEventKind(Modify(Metadata(Ownership))), "/Users/wiggles/mwb4/src/4913",    file_type: None
-^ This is technically a rename due to How It Works. We can tell it's not a "real rename" because
-  there's no removed `.hs` files.
-^ I think the only real way to tell if it's a rename or not is to check if the paths are in the
-  loaded module set or not?
-
-Events when I write an existing source file in VSCode:
-• FileEventKind(Modify(Metadata(Any))) "/Users/wiggles/mwb4/src/App.hs" file_type: Some(File)
-• FileEventKind(Modify(Data(Content))) "/Users/wiggles/mwb4/src/App.hs" file_type: Some(File)
-^ A `Modify(Data(Content))` and `Modify(Metadata(_))` and nothing else for that path.
-
-Events when I create a new file:
-• FileEventKind(Create(Folder)),        "/Users/wiggles/mwb4/src/Foo",             file_type: Some(Dir)
-• FileEventKind(Create(File)),          "/Users/wiggles/mwb4/src/Foo/MyModule.hs", file_type: Some(File)
-• FileEventKind(Modify(Data(Content))), "/Users/wiggles/mwb4/src/Foo/MyModule.hs", file_type: Some(File)
-^ There's a `Create(File)` and `Modify(Data(_))`and nothing else for that path.
-
-Events when I `rm -rf` a directory:
-• FileEventKind(Remove(File)),   "/Users/wiggles/mwb4/src/Foo/MyModule.hs", file_type: None
-• FileEventKind(Remove(Folder)), "/Users/wiggles/mwb4/src/Foo",             file_type: None
-^ Note that these both have `file_type: None`.
-^ There's a `Remove(File)` event and nothing else for that path.
-
-Events when I `mv` a module to a new location:
-• FileEventKind(Create(File)),          "/Users/wiggles/mwb4/src/Foo/MyModule.hs",     file_type: None
-• FileEventKind(Modify(Data(Content))), "/Users/wiggles/mwb4/src/Foo/MyModule.hs",     file_type: None
-• FileEventKind(Modify(Name(Any))),     "/Users/wiggles/mwb4/src/Foo/MyModule.hs",     file_type: None
-• FileEventKind(Modify(Name(Any))),     "/Users/wiggles/mwb4/src/Foo/MyCoolModule.hs", file_type: Some(File)
-^ There's a `Modify(Name(_))` event for the new and old paths. The new path has a `file_type: Some(File)`.
-^ No good way to tell _what_ file it was renamed from.
-^ Why is the old (removed) file marked as `Create(File)`???
-
- */
-
-/// A filesystem event that `ghci` will need to respond to. Due to the way that `ghci` is, we need
-/// to divide these into a few different classes so that we can respond appropriately.
+/// A set of filesystem events that `ghci` will need to respond to. Due to the way that `ghci` is,
+/// we need to divide these into a few different classes so that we can respond appropriately.
+#[derive(Debug)]
 pub enum FileEvent {
-    /// An existing file is modified, or a new file is created.
+    /// Existing files that are modified, or new files that are created.
     ///
     /// `inotify` APIs aren't great at distinguishing between newly-created files and modified
     /// existing files (particularly because some editors, like `vim`, will write to a temporary
@@ -89,69 +31,36 @@ impl FileEvent {
     }
 }
 
-/// Process the events contained in an [`Action`] into a list of [`FileEvent`]s.
-pub fn file_events_from_action(action: &Action) -> miette::Result<Vec<FileEvent>> {
-    // First, build up a map from paths to events tagged with that path.
-    // This will give us easy access to the events for a given path in this batch.
-    let mut events_by_path = HashMap::<Utf8PathBuf, Vec<&Event>>::new();
-    for event in action.events.iter() {
-        for tag in event.tags.iter() {
-            if let Tag::Path { path, .. } = tag {
-                let path = path.to_owned().try_into().into_diagnostic()?;
-                let entry = events_by_path.entry(path).or_default();
-                entry.push(event);
-                // No need to look at the rest of the tags.
-                break;
-            }
-        }
-    }
+/// Process a set of events into a set of [`FileEvent`]s.
+pub fn file_events_from_action(events: Vec<DebouncedEvent>) -> miette::Result<Vec<FileEvent>> {
+    let mut ret = Vec::with_capacity(events.len());
 
-    let mut ret = Vec::new();
-
-    for (path, events) in events_by_path.iter() {
-        let mut exists = false;
-        let mut created = false;
+    for event in events {
+        let event = event.event;
         let mut modified = false;
         let mut removed = false;
-        let mut renamed = false;
-        for event in events {
-            for tag in event.tags.iter() {
-                match tag {
-                    Tag::Path { path: _, file_type } => {
-                        exists = file_type.is_some();
-                    }
-                    Tag::FileEventKind(FileEventKind::Modify(ModifyKind::Name(_))) => {
-                        renamed = true;
-                    }
-                    Tag::FileEventKind(FileEventKind::Modify(_)) => {
-                        modified = true;
-                    }
-                    Tag::FileEventKind(FileEventKind::Create(_)) => {
-                        created = true;
-                    }
-                    Tag::FileEventKind(FileEventKind::Remove(_)) => {
-                        removed = true;
-                    }
-                    _ => {}
-                }
+        match event.kind {
+            EventKind::Remove(_) => {
+                removed = true;
+            }
+
+            EventKind::Any | EventKind::Other | EventKind::Create(_) | EventKind::Modify(_) => {
+                modified = true;
+            }
+
+            EventKind::Access(_) => {
+                // Non-mutating event, ignore these.
             }
         }
 
-        // Write existing file from Vim:    exists, renamed, created, modified
-        // Write existing file from VSCode: exists,                   modified
-        // Create a new file:               exists,          created, modified
-        // `mv`:                            exists, renamed
-        // `rm -rf`:                        !exists,                            removed
-        //
-        // We can't distinguish between modifying an existing file and creating a new one.
-        //
-        // We could probably just use `modified` and ignore the `created` and `renamed` values
-        // here.
+        for path in event.paths {
+            let path: Utf8PathBuf = path.try_into().into_diagnostic()?;
 
-        if !exists || removed {
-            ret.push(FileEvent::Remove(path.clone()));
-        } else if modified || created || renamed {
-            ret.push(FileEvent::Modify(path.clone()));
+            if !path.exists() || removed {
+                ret.push(FileEvent::Remove(path));
+            } else if modified {
+                ret.push(FileEvent::Modify(path));
+            }
         }
     }
 

--- a/src/ghci/manager.rs
+++ b/src/ghci/manager.rs
@@ -1,0 +1,59 @@
+//! Subsystem for [`Ghci`] to support graceful shutdown.
+
+use miette::Context;
+use tokio::sync::mpsc;
+use tracing::instrument;
+
+use crate::event_filter::FileEvent;
+use crate::ghci::process::GhciProcessState;
+use crate::shutdown::ShutdownHandle;
+
+use super::Ghci;
+use super::GhciOpts;
+
+/// An event sent to [`Ghci`].
+#[derive(Debug)]
+pub enum GhciEvent {
+    /// Reload the `ghci` session.
+    Reload {
+        /// The file events to respond to.
+        events: Vec<FileEvent>,
+    },
+}
+
+/// Start the [`Ghci`] subsystem.
+#[instrument(skip_all, level = "debug")]
+pub async fn run_ghci(
+    mut handle: ShutdownHandle,
+    opts: GhciOpts,
+    mut receiver: mpsc::Receiver<GhciEvent>,
+) -> miette::Result<()> {
+    let mut ghci = Ghci::new(handle.clone(), opts)
+        .await
+        .wrap_err("Failed to start `ghci`")?;
+
+    loop {
+        tokio::select! {
+            _ = handle.on_shutdown_requested() => {
+                if ghci.get_process_state().await == GhciProcessState::Running {
+                    ghci.stop().await.wrap_err("Failed to quit ghci")?;
+                }
+                break;
+            }
+            Some(event) = receiver.recv() => {
+                dispatch(&mut ghci, event).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn dispatch(ghci: &mut Ghci, event: GhciEvent) -> miette::Result<()> {
+    match event {
+        GhciEvent::Reload { events } => {
+            ghci.reload(events).await?;
+        }
+    }
+    Ok(())
+}

--- a/src/ghci/manager.rs
+++ b/src/ghci/manager.rs
@@ -49,6 +49,7 @@ pub async fn run_ghci(
     Ok(())
 }
 
+#[instrument(level = "debug", skip(ghci))]
 async fn dispatch(ghci: &mut Ghci, event: GhciEvent) -> miette::Result<()> {
     match event {
         GhciEvent::Reload { events } => {

--- a/src/ghci/process.rs
+++ b/src/ghci/process.rs
@@ -35,6 +35,7 @@ impl GhciProcess {
             }
             _ = self.restart_receiver.recv() => {
                 tracing::debug!("ghci is being shut down");
+                self.stop().await?;
             }
             result = self.process.wait() => {
                 self.exited(result.into_diagnostic()?).await;

--- a/src/ghci/process.rs
+++ b/src/ghci/process.rs
@@ -63,6 +63,7 @@ impl GhciProcess {
         }
 
         // Kill it otherwise.
+        tracing::debug!("Killing ghci ungracefully");
         self.process.kill().await.into_diagnostic()?;
         // Report the exit status.
         if let Some(status) = self.process.try_wait().into_diagnostic()? {

--- a/src/ghci/process.rs
+++ b/src/ghci/process.rs
@@ -1,8 +1,6 @@
 use std::future::Future;
 use std::pin::Pin;
 use std::process::ExitStatus;
-use std::sync::Arc;
-use std::time::Duration;
 
 use command_group::AsyncGroupChild;
 use miette::Context;
@@ -11,26 +9,17 @@ use nix::sys::signal;
 use nix::sys::signal::Signal;
 use nix::unistd::Pid;
 use tokio::sync::mpsc;
-use tokio::sync::Mutex;
 use tracing::instrument;
 
 use crate::shutdown::ShutdownHandle;
 
-/// The state of a `ghci` process.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum GhciProcessState {
-    /// The process is still running.
-    #[default]
-    Running,
-    /// The process has exited.
-    Exited,
-}
-
 pub struct GhciProcess {
     pub shutdown: ShutdownHandle,
     pub process_group_id: Pid,
+    /// Notifies this task to _not_ request a shutdown for the entire program when `ghci` exits.
+    /// This is used for the graceful shutdown implementation and for routine `ghci` session
+    /// restarts.
     pub restart_receiver: mpsc::Receiver<()>,
-    pub state: Arc<Mutex<GhciProcessState>>,
 }
 
 impl GhciProcess {
@@ -58,39 +47,22 @@ impl GhciProcess {
     #[instrument(skip_all, level = "debug")]
     async fn stop(
         &self,
-        mut wait: Pin<&mut impl Future<Output = Result<ExitStatus, std::io::Error>>>,
+        wait: Pin<&mut impl Future<Output = Result<ExitStatus, std::io::Error>>>,
     ) -> miette::Result<()> {
-        let status = async {
-            // Give `ghci` a bit for a graceful shutdown.
-            match tokio::time::timeout(Duration::from_secs(10), &mut wait).await {
-                Ok(Ok(status)) => {
-                    return Ok(status);
-                }
-                Ok(Err(err)) => {
-                    tracing::debug!("Failed to wait for ghci: {err}");
-                }
-                Err(_) => {
-                    // Timeout expired.
-                    tracing::debug!("ghci didn't exit in time");
-                }
-            }
-
-            // Kill it otherwise.
-            tracing::debug!("Killing ghci ungracefully");
-            // This is what `self.process.kill()` does, but we can't call that due to borrow
-            // checker shennanigans.
-            signal::killpg(self.process_group_id, Signal::SIGKILL)
-                .into_diagnostic()
-                .wrap_err_with(|| {
-                    format!(
-                        "Failed to kill ghci process (pid {})",
-                        self.process_group_id
-                    )
-                })?;
-            // Report the exit status.
-            wait.await.into_diagnostic()
-        }
-        .await?;
+        // Kill it otherwise.
+        tracing::debug!("Killing ghci process tree with SIGKILL");
+        // This is what `self.process.kill()` does, but we can't call that due to borrow
+        // checker shennanigans.
+        signal::killpg(self.process_group_id, Signal::SIGKILL)
+            .into_diagnostic()
+            .wrap_err_with(|| {
+                format!(
+                    "Failed to kill ghci process (pid {})",
+                    self.process_group_id
+                )
+            })?;
+        // Report the exit status.
+        let status = wait.await.into_diagnostic()?;
 
         self.exited(status).await;
         Ok(())
@@ -98,6 +70,5 @@ impl GhciProcess {
 
     async fn exited(&self, status: ExitStatus) {
         tracing::debug!("ghci exited: {status}");
-        *self.state.lock().await = GhciProcessState::Exited;
     }
 }

--- a/src/ghci/process.rs
+++ b/src/ghci/process.rs
@@ -1,0 +1,78 @@
+use std::process::ExitStatus;
+use std::sync::Arc;
+
+use miette::IntoDiagnostic;
+use tokio::process::Child;
+use tokio::sync::mpsc;
+use tokio::sync::Mutex;
+use tracing::instrument;
+
+use crate::shutdown::ShutdownHandle;
+
+/// The state of a `ghci` process.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum GhciProcessState {
+    /// The process is still running.
+    #[default]
+    Running,
+    /// The process has exited.
+    Exited,
+}
+
+pub struct GhciProcess {
+    pub shutdown: ShutdownHandle,
+    pub process: Child,
+    pub restart_receiver: mpsc::Receiver<()>,
+    pub state: Arc<Mutex<GhciProcessState>>,
+}
+
+impl GhciProcess {
+    #[instrument(skip_all, name = "ghci_process", level = "debug")]
+    pub async fn run(mut self) -> miette::Result<()> {
+        tokio::select! {
+            _ = self.shutdown.on_shutdown_requested() => {
+                self.stop().await?;
+            }
+            _ = self.restart_receiver.recv() => {
+                tracing::debug!("ghci is being shut down");
+            }
+            result = self.process.wait() => {
+                self.exited(result.into_diagnostic()?).await;
+                let _ = self.shutdown.request_shutdown();
+            }
+        }
+        Ok(())
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    async fn stop(&mut self) -> miette::Result<()> {
+        // Give `ghci` a half second for a graceful shutdown.
+        match tokio::time::timeout(std::time::Duration::from_millis(500), self.process.wait()).await
+        {
+            Ok(Ok(status)) => {
+                self.exited(status).await;
+                return Ok(());
+            }
+            Ok(Err(err)) => {
+                tracing::debug!("Failed to wait for ghci: {err}");
+            }
+            Err(_) => {
+                // Timeout expired.
+                tracing::debug!("ghci didn't exit in time");
+            }
+        }
+
+        // Kill it otherwise.
+        self.process.kill().await.into_diagnostic()?;
+        // Report the exit status.
+        if let Some(status) = self.process.try_wait().into_diagnostic()? {
+            self.exited(status).await;
+        }
+        Ok(())
+    }
+
+    async fn exited(&mut self, status: ExitStatus) {
+        tracing::debug!("ghci exited: {status}");
+        *self.state.lock().await = GhciProcessState::Exited;
+    }
+}

--- a/src/ghci/process.rs
+++ b/src/ghci/process.rs
@@ -1,9 +1,15 @@
+use std::future::Future;
+use std::pin::Pin;
 use std::process::ExitStatus;
 use std::sync::Arc;
 use std::time::Duration;
 
 use command_group::AsyncGroupChild;
+use miette::Context;
 use miette::IntoDiagnostic;
+use nix::sys::signal;
+use nix::sys::signal::Signal;
+use nix::unistd::Pid;
 use tokio::sync::mpsc;
 use tokio::sync::Mutex;
 use tracing::instrument;
@@ -22,23 +28,26 @@ pub enum GhciProcessState {
 
 pub struct GhciProcess {
     pub shutdown: ShutdownHandle,
-    pub process: AsyncGroupChild,
+    pub process_group_id: Pid,
     pub restart_receiver: mpsc::Receiver<()>,
     pub state: Arc<Mutex<GhciProcessState>>,
 }
 
 impl GhciProcess {
     #[instrument(skip_all, name = "ghci_process", level = "debug")]
-    pub async fn run(mut self) -> miette::Result<()> {
+    pub async fn run(mut self, mut process: AsyncGroupChild) -> miette::Result<()> {
+        // We can only call `wait()` once at a time, so we store the future and pass it into the
+        // `stop()` handler.
+        let mut wait = std::pin::pin!(process.wait());
         tokio::select! {
             _ = self.shutdown.on_shutdown_requested() => {
-                self.stop().await?;
+                self.stop(wait).await?;
             }
             _ = self.restart_receiver.recv() => {
                 tracing::debug!("ghci is being shut down");
-                self.stop().await?;
+                self.stop(wait).await?;
             }
-            result = self.process.wait() => {
+            result = &mut wait => {
                 self.exited(result.into_diagnostic()?).await;
                 let _ = self.shutdown.request_shutdown();
             }
@@ -46,43 +55,48 @@ impl GhciProcess {
         Ok(())
     }
 
-    #[instrument(skip(self), level = "debug")]
-    async fn stop(&mut self) -> miette::Result<()> {
-        // Give `ghci` a bit for a graceful shutdown.
-        match tokio::time::timeout(std::time::Duration::from_secs(10), self.process.wait()).await {
-            Ok(Ok(status)) => {
-                self.exited(status).await;
-                return Ok(());
+    #[instrument(skip_all, level = "debug")]
+    async fn stop(
+        &self,
+        mut wait: Pin<&mut impl Future<Output = Result<ExitStatus, std::io::Error>>>,
+    ) -> miette::Result<()> {
+        let status = async {
+            // Give `ghci` a bit for a graceful shutdown.
+            match tokio::time::timeout(Duration::from_secs(10), &mut wait).await {
+                Ok(Ok(status)) => {
+                    return Ok(status);
+                }
+                Ok(Err(err)) => {
+                    tracing::debug!("Failed to wait for ghci: {err}");
+                }
+                Err(_) => {
+                    // Timeout expired.
+                    tracing::debug!("ghci didn't exit in time");
+                }
             }
-            Ok(Err(err)) => {
-                tracing::debug!("Failed to wait for ghci: {err}");
-            }
-            Err(_) => {
-                // Timeout expired.
-                tracing::debug!("ghci didn't exit in time");
-            }
-        }
 
-        // Kill it otherwise.
-        tracing::debug!("Killing ghci ungracefully");
-        self.process.kill().into_diagnostic()?;
-        // Report the exit status.
-        loop {
-            match self.process.wait().await {
-                Ok(status) => {
-                    self.exited(status).await;
-                    break;
-                }
-                Err(err) => {
-                    tracing::error!("{err}");
-                }
-            }
-            tokio::time::sleep(Duration::from_millis(250)).await;
+            // Kill it otherwise.
+            tracing::debug!("Killing ghci ungracefully");
+            // This is what `self.process.kill()` does, but we can't call that due to borrow
+            // checker shennanigans.
+            signal::killpg(self.process_group_id, Signal::SIGKILL)
+                .into_diagnostic()
+                .wrap_err_with(|| {
+                    format!(
+                        "Failed to kill ghci process (pid {})",
+                        self.process_group_id
+                    )
+                })?;
+            // Report the exit status.
+            wait.await.into_diagnostic()
         }
+        .await?;
+
+        self.exited(status).await;
         Ok(())
     }
 
-    async fn exited(&mut self, status: ExitStatus) {
+    async fn exited(&self, status: ExitStatus) {
         tracing::debug!("ghci exited: {status}");
         *self.state.lock().await = GhciProcessState::Exited;
     }

--- a/src/ghci/stdin.rs
+++ b/src/ghci/stdin.rs
@@ -189,6 +189,7 @@ impl GhciStdin {
 
     #[instrument(skip(self, stdout), level = "debug")]
     pub async fn quit(&mut self, stdout: &mut GhciStdout) -> miette::Result<()> {
+        let _ = self.set_mode(stdout, Mode::Internal).await;
         self.stdin
             .write_all(b":quit\n")
             .await

--- a/src/ghci/stdin.rs
+++ b/src/ghci/stdin.rs
@@ -7,7 +7,6 @@ use tokio::io::AsyncWriteExt;
 use tokio::process::ChildStdin;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
-use tokio::task::JoinSet;
 use tracing::instrument;
 
 use crate::incremental_reader::FindAt;

--- a/src/ghci/stdout.rs
+++ b/src/ghci/stdout.rs
@@ -129,12 +129,13 @@ impl GhciStdout {
 
     #[instrument(skip_all, level = "debug")]
     pub async fn quit(&mut self) -> miette::Result<()> {
+        // self.prompt(FindAt::LineStart).await?;
         let leaving_ghci = AhoCorasick::from_anchored_patterns(["Leaving GHCi."]);
         let _data = self
             .reader
             .read_until(&mut ReadOpts {
                 end_marker: &leaving_ghci,
-                find: FindAt::LineStart,
+                find: FindAt::Anywhere,
                 writing: WriteBehavior::Write,
                 buffer: &mut self.buffer,
             })

--- a/src/ghci/stdout.rs
+++ b/src/ghci/stdout.rs
@@ -131,7 +131,7 @@ impl GhciStdout {
     pub async fn quit(&mut self) -> miette::Result<()> {
         // self.prompt(FindAt::LineStart).await?;
         let leaving_ghci = AhoCorasick::from_anchored_patterns(["Leaving GHCi."]);
-        let _data = self
+        let data = self
             .reader
             .read_until(&mut ReadOpts {
                 end_marker: &leaving_ghci,
@@ -140,6 +140,7 @@ impl GhciStdout {
                 buffer: &mut self.buffer,
             })
             .await?;
+        tracing::debug!(data, "ghci confirmed quit on stdout");
         Ok(())
     }
 

--- a/src/ghci/stdout.rs
+++ b/src/ghci/stdout.rs
@@ -129,11 +129,11 @@ impl GhciStdout {
 
     #[instrument(skip_all, level = "debug")]
     pub async fn quit(&mut self) -> miette::Result<()> {
-        let bootup_patterns = AhoCorasick::from_anchored_patterns(["Leaving GHCi."]);
+        let leaving_ghci = AhoCorasick::from_anchored_patterns(["Leaving GHCi."]);
         let _data = self
             .reader
             .read_until(&mut ReadOpts {
-                end_marker: &bootup_patterns,
+                end_marker: &leaving_ghci,
                 find: FindAt::LineStart,
                 writing: WriteBehavior::Write,
                 buffer: &mut self.buffer,

--- a/src/ghci/stdout.rs
+++ b/src/ghci/stdout.rs
@@ -127,6 +127,21 @@ impl GhciStdout {
         ModuleSet::from_paths(paths, &search_paths.cwd)
     }
 
+    #[instrument(skip_all, level = "debug")]
+    pub async fn quit(&mut self) -> miette::Result<()> {
+        let bootup_patterns = AhoCorasick::from_anchored_patterns(["Leaving GHCi."]);
+        let _data = self
+            .reader
+            .read_until(&mut ReadOpts {
+                end_marker: &bootup_patterns,
+                find: FindAt::LineStart,
+                writing: WriteBehavior::Write,
+                buffer: &mut self.buffer,
+            })
+            .await?;
+        Ok(())
+    }
+
     pub fn set_mode(&mut self, mode: Mode) {
         self.mode = mode;
     }

--- a/src/incremental_reader.rs
+++ b/src/incremental_reader.rs
@@ -4,7 +4,6 @@ use std::pin::Pin;
 
 use aho_corasick::AhoCorasick;
 use line_span::LineSpans;
-use miette::miette;
 use miette::IntoDiagnostic;
 use miette::WrapErr;
 use tokio::io::AsyncRead;
@@ -94,7 +93,7 @@ where
         match self.reader.read(opts.buffer).await {
             Ok(0) => {
                 // EOF
-                Err(miette!("End-of-file reached"))
+                Ok(None)
             }
             Ok(n) => {
                 let decoded = std::str::from_utf8(&opts.buffer[..n])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,16 +24,20 @@ mod ghci;
 mod haskell_source_file;
 mod incremental_reader;
 mod normal_path;
+mod shutdown;
 mod textwrap;
 mod tracing;
 mod watcher;
 
 pub(crate) use format_bulleted_list::format_bulleted_list;
 
-pub use ghci::Ghci;
+pub use ghci::manager::run_ghci;
 pub use ghci::GhciOpts;
+pub use shutdown::ShutdownError;
+pub use shutdown::ShutdownHandle;
+pub use shutdown::ShutdownManager;
 pub use tracing::TracingOpts;
-pub use watcher::Watcher;
+pub use watcher::run_watcher;
 pub use watcher::WatcherOpts;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ mod watcher;
 pub(crate) use format_bulleted_list::format_bulleted_list;
 
 pub use ghci::manager::run_ghci;
+pub use ghci::Ghci;
 pub use ghci::GhciOpts;
 pub use shutdown::ShutdownError;
 pub use shutdown::ShutdownHandle;

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,5 +39,7 @@ async fn main() -> miette::Result<()> {
             run_watcher(handle, ghci_sender, watcher_opts)
         })
         .await;
-    manager.wait_for_shutdown().await
+    let ret = manager.wait_for_shutdown().await;
+    tracing::debug!("come on");
+    ret
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,15 +4,17 @@
 //! `ghciwatch` watches your modules for changes and reloads them in a `ghci` session, displaying
 //! any errors.
 
+use std::time::Duration;
+
 use clap::Parser;
 use ghciwatch::cli;
-use ghciwatch::Ghci;
+use ghciwatch::run_ghci;
+use ghciwatch::run_watcher;
 use ghciwatch::GhciOpts;
+use ghciwatch::ShutdownManager;
 use ghciwatch::TracingOpts;
-use ghciwatch::Watcher;
 use ghciwatch::WatcherOpts;
-use miette::IntoDiagnostic;
-use miette::WrapErr;
+use tokio::sync::mpsc;
 
 #[tokio::main]
 async fn main() -> miette::Result<()> {
@@ -21,21 +23,21 @@ async fn main() -> miette::Result<()> {
     opts.init()?;
     TracingOpts::from_cli(&opts).install()?;
 
-    ::tracing::warn!(
-        "This is a prerelease alpha version of `ghciwatch`! Expect a rough user experience, and please report bugs or other issues to the #mighty-dux channel on Slack."
-    );
+    let (ghci_sender, ghci_receiver) = mpsc::channel(32);
 
-    let ghci = Ghci::new(GhciOpts::from_cli(&opts)?)
-        .await
-        .wrap_err("Failed to start `ghci`")?;
-    let watcher = Watcher::new(ghci, WatcherOpts::from_cli(&opts))
-        .wrap_err("Failed to start file watcher")?;
+    let ghci_opts = GhciOpts::from_cli(&opts)?;
+    let watcher_opts = WatcherOpts::from_cli(&opts);
 
-    watcher
-        .handle
-        .await
-        .into_diagnostic()?
-        .wrap_err("File watcher failed")?;
-
-    Ok(())
+    let mut manager = ShutdownManager::with_timeout(Duration::from_millis(1000));
+    manager
+        .spawn("ghci".to_owned(), |handle| {
+            run_ghci(handle, ghci_opts, ghci_receiver)
+        })
+        .await;
+    manager
+        .spawn("File watcher".to_owned(), move |handle| {
+            run_watcher(handle, ghci_sender, watcher_opts)
+        })
+        .await;
+    manager.wait_for_shutdown().await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ async fn main() -> miette::Result<()> {
     let ghci_opts = GhciOpts::from_cli(&opts)?;
     let watcher_opts = WatcherOpts::from_cli(&opts);
 
-    let mut manager = ShutdownManager::with_timeout(Duration::from_millis(1000));
+    let mut manager = ShutdownManager::with_timeout(Duration::from_millis(10_000));
     manager
         .spawn("ghci".to_owned(), |handle| {
             run_ghci(handle, ghci_opts, ghci_receiver)

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,12 +30,12 @@ async fn main() -> miette::Result<()> {
 
     let mut manager = ShutdownManager::with_timeout(Duration::from_millis(10_000));
     manager
-        .spawn("ghci".to_owned(), |handle| {
+        .spawn("run_ghci".to_owned(), |handle| {
             run_ghci(handle, ghci_opts, ghci_receiver)
         })
         .await;
     manager
-        .spawn("File watcher".to_owned(), move |handle| {
+        .spawn("run_watcher".to_owned(), move |handle| {
             run_watcher(handle, ghci_sender, watcher_opts)
         })
         .await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,6 @@ async fn main() -> miette::Result<()> {
         })
         .await;
     let ret = manager.wait_for_shutdown().await;
-    tracing::debug!("come on");
+    tracing::debug!("main() finished");
     ret
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ async fn main() -> miette::Result<()> {
     let ghci_opts = GhciOpts::from_cli(&opts)?;
     let watcher_opts = WatcherOpts::from_cli(&opts);
 
-    let mut manager = ShutdownManager::with_timeout(Duration::from_millis(10_000));
+    let mut manager = ShutdownManager::with_timeout(Duration::from_secs(1));
     manager
         .spawn("run_ghci".to_owned(), |handle| {
             run_ghci(handle, ghci_opts, ghci_receiver)

--- a/src/normal_path.rs
+++ b/src/normal_path.rs
@@ -1,5 +1,3 @@
-//! Wrapper type for normalized [`Utf8PathBuf`]s.
-
 use std::borrow::Borrow;
 use std::fmt::Debug;
 use std::fmt::Display;

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -111,9 +111,9 @@ impl ShutdownManager {
                 _ = self.guard_receiver.recv() => {
                     tracing::debug!("All tasks finished");
                 }
-                // _ = tokio::time::sleep(self.timeout) => {
-                    // tracing::debug!("Graceful shutdown timed out");
-                // }
+                _ = tokio::time::sleep(self.timeout) => {
+                    tracing::debug!("Graceful shutdown timed out");
+                }
             }
         }
         // Note any unfinished tasks, cancel everything, and check the return values.

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -68,11 +68,6 @@ impl ShutdownManager {
     {
         let sender = self.sender.clone();
         let receiver = sender.subscribe();
-        // wrap the future?
-        // -request shutdowns when tasks fail
-        // -cancel tasks from here
-        // -check if finished
-        // -check if failed later
         let handle = tokio::task::spawn(make_task(ShutdownHandle {
             sender,
             receiver,
@@ -239,6 +234,7 @@ impl ShutdownHandle {
     }
 
     /// Request a shutdown.
+    #[instrument(level = "debug", skip_all)]
     pub fn request_shutdown(&self) -> Result<(), broadcast::error::SendError<()>> {
         self.sender.send(()).map(|_| ())
     }

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -16,6 +16,7 @@ use tokio::sync::oneshot;
 use tokio::sync::Mutex;
 use tokio::task::AbortHandle;
 use tokio::task::JoinHandle;
+use tracing::instrument;
 
 use crate::format_bulleted_list::format_bulleted_list;
 
@@ -59,6 +60,7 @@ impl ShutdownManager {
     }
 
     /// Run a new task in this manager.
+    #[instrument(level = "debug", skip_all)]
     pub async fn spawn<F, Fut>(&mut self, name: String, make_task: F)
     where
         F: FnOnce(ShutdownHandle) -> Fut,
@@ -83,6 +85,7 @@ impl ShutdownManager {
     }
 
     /// Wait for tasks to shut down/error or Ctrl-C to be pressed and then shuts down gracefully.
+    #[instrument(level = "debug", skip_all)]
     pub async fn wait_for_shutdown(mut self) -> miette::Result<()> {
         drop(self.guard_sender);
         let mut all_finished = false;
@@ -106,6 +109,9 @@ impl ShutdownManager {
         // If we still have running tasks, begin the graceful shutdown procedure.
         let start_instant = Instant::now();
         if !all_finished {
+            tracing::debug!(
+                "Waiting for second Ctrl-C, all tasks to finish, or shutdown timeout to expire"
+            );
             tokio::select! {
                 _ = tokio::signal::ctrl_c() => {
                     tracing::debug!("Ctrl-C pressed again, shutting down immediately");
@@ -136,21 +142,35 @@ impl Handles {
         self.0.lock().await.push(task);
     }
 
+    #[instrument(level = "debug", skip_all)]
     async fn cancel_tasks(&self) {
         for task in self.0.lock().await.iter() {
-            if !task.is_finished() {
-                tracing::debug!(task = task.name, "Task is unfinished");
+            if task.is_finished() {
+                tracing::debug!(task = task.name, "Task is finished");
+            } else {
+                tracing::debug!(task = task.name, "Task is unfinished, cancelling");
+                task.cancel();
             }
-            task.cancel();
         }
     }
 
+    #[instrument(level = "debug", skip_all)]
     async fn check_task_failures(&mut self) -> miette::Result<()> {
         let mut failures = Vec::new();
 
         for task in std::mem::take(self.0.lock().await.deref_mut()) {
-            if let Some(err) = task.into_result().await? {
-                failures.push(err);
+            let name = task.name.clone();
+            tracing::debug!(task = name, "Getting result for task");
+            match task.into_result().await {
+                Ok(Some(err)) => {
+                    failures.push(err);
+                }
+                Ok(None) => {
+                    tracing::debug!(task = name, "Task completed successfully");
+                }
+                Err(err) => {
+                    tracing::debug!(task = name, "Failed to get result for task: {err:?}");
+                }
             }
         }
 
@@ -198,6 +218,7 @@ impl Clone for ShutdownHandle {
 
 impl ShutdownHandle {
     /// Wait until a shutdown is requested.
+    #[instrument(level = "debug", skip_all)]
     pub async fn on_shutdown_requested(&mut self) -> Result<(), broadcast::error::RecvError> {
         self.receiver.recv().await
     }
@@ -205,6 +226,7 @@ impl ShutdownHandle {
     /// Check if a shutdown has been requested; if so, return a [`ShutdownError`].
     ///
     /// Otherwise, return `Ok(())`.
+    #[instrument(level = "debug", skip_all)]
     pub fn error_if_shutdown_requested(&mut self) -> miette::Result<()> {
         match self.receiver.try_recv() {
             Ok(()) | Err(broadcast::error::TryRecvError::Lagged(_)) => Err(ShutdownError.into()),
@@ -319,6 +341,7 @@ async fn manage_handle(
         }
     }
     if ret.is_some() {
+        tracing::debug!(task = name, "Task errored, requesting shutdown");
         let _ = request_shutdown.send(());
     }
     let _ = sender.send(ret);

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -1,0 +1,350 @@
+//! Graceful shutdown support.
+
+use std::error::Error;
+use std::fmt::Display;
+use std::future::Future;
+use std::ops::DerefMut;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+
+use miette::miette;
+use miette::IntoDiagnostic;
+use tokio::sync::broadcast;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tokio::sync::Mutex;
+use tokio::task::AbortHandle;
+use tokio::task::JoinHandle;
+
+use crate::format_bulleted_list::format_bulleted_list;
+
+/// A manager for shutting down the program gracefully.
+pub struct ShutdownManager {
+    /// Sender for shutdown events. Notifies different parts of the program that it's time to shut
+    /// down.
+    sender: broadcast::Sender<()>,
+    // Receiver for shutdown events.
+    //
+    // The shutdown process begins when this receives a value.
+    receiver: broadcast::Receiver<()>,
+    /// Shutdown timeout. If the shutdown takes longer than this, we start cancelling tasks.
+    timeout: Duration,
+    /// The tasks being run.
+    handles: Handles,
+    /// Shutdown guard. Senders are passed to each future spawned with [`ShutdownManager::spawn`]
+    /// so that they're dropped when the task completes. Then, when there are no remaining senders,
+    /// the channel is closed and the `guard_receiver` errors, indicating that all tasks have
+    /// completed.
+    ///
+    /// See: <https://tokio.rs/tokio/topics/shutdown#waiting-for-things-to-finish-shutting-down>
+    guard_sender: mpsc::Sender<()>,
+    /// Shutdown guard receiver.
+    guard_receiver: mpsc::Receiver<()>,
+}
+
+impl ShutdownManager {
+    /// Construct a new shutdown manager with the given timeout for graceful shutdowns.
+    pub fn with_timeout(timeout: Duration) -> Self {
+        let (sender, receiver) = broadcast::channel(4);
+        let (guard_sender, guard_receiver) = mpsc::channel(1);
+        Self {
+            timeout,
+            sender,
+            receiver,
+            handles: Default::default(),
+            guard_receiver,
+            guard_sender,
+        }
+    }
+
+    /// Run a new task in this manager.
+    pub async fn spawn<F, Fut>(&mut self, name: String, make_task: F)
+    where
+        F: FnOnce(ShutdownHandle) -> Fut,
+        Fut: Future<Output = miette::Result<()>> + Send + 'static,
+    {
+        let sender = self.sender.clone();
+        let receiver = sender.subscribe();
+        // wrap the future?
+        // -request shutdowns when tasks fail
+        // -cancel tasks from here
+        // -check if finished
+        // -check if failed later
+        let handle = tokio::task::spawn(make_task(ShutdownHandle {
+            sender,
+            receiver,
+            guard: self.guard_sender.clone(),
+            handles: self.handles.clone(),
+        }));
+        self.handles
+            .push(Task::new(name, handle, self.sender.clone()))
+            .await;
+    }
+
+    /// Wait for tasks to shut down/error or Ctrl-C to be pressed and then shuts down gracefully.
+    pub async fn wait_for_shutdown(mut self) -> miette::Result<()> {
+        drop(self.guard_sender);
+        let mut all_finished = false;
+
+        // Wait for a shutdown to be requested or the tasks to finish.
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                tracing::debug!("Ctrl-C pressed, shutting down gracefully");
+                // Note that we need to trigger the shutdown manually in this case.
+                self.sender.send(()).into_diagnostic()?;
+            }
+            _ = self.guard_receiver.recv() => {
+                tracing::debug!("All tasks finished");
+                all_finished = true;
+            }
+            _ = self.receiver.recv() => {
+                tracing::debug!("Shutdown requested");
+            }
+        }
+
+        // If we still have running tasks, begin the graceful shutdown procedure.
+        let start_instant = Instant::now();
+        if !all_finished {
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {
+                    tracing::debug!("Ctrl-C pressed again, shutting down immediately");
+                }
+                _ = self.guard_receiver.recv() => {
+                    tracing::debug!("All tasks finished");
+                }
+                _ = tokio::time::sleep(self.timeout) => {
+                    tracing::debug!("Graceful shutdown timed out");
+                }
+            }
+        }
+        // Note any unfinished tasks, cancel everything, and check the return values.
+        self.handles.cancel_tasks().await;
+        let ret = self.handles.check_task_failures().await;
+
+        tracing::debug!("Finished shutdown in {:.2?}", start_instant.elapsed());
+        ret
+    }
+}
+
+/// A set of tasks being run.
+#[derive(Debug, Clone, Default)]
+struct Handles(Arc<Mutex<Vec<Task>>>);
+
+impl Handles {
+    async fn push(&mut self, task: Task) {
+        self.0.lock().await.push(task);
+    }
+
+    async fn cancel_tasks(&self) {
+        for task in self.0.lock().await.iter() {
+            if !task.is_finished() {
+                tracing::debug!(task = task.name, "Task is unfinished");
+            }
+            task.cancel();
+        }
+    }
+
+    async fn check_task_failures(&mut self) -> miette::Result<()> {
+        let mut failures = Vec::new();
+
+        for task in std::mem::take(self.0.lock().await.deref_mut()) {
+            if let Some(err) = task.into_result().await? {
+                failures.push(err);
+            }
+        }
+
+        if failures.is_empty() {
+            tracing::debug!("All tasks completed successfully");
+            Ok(())
+        } else {
+            let failures = format_bulleted_list(
+                failures
+                    .into_iter()
+                    .map(|(name, error)| format!("{name}: {error}")),
+            );
+            Err(miette!("Tasks failed:\n{failures}"))
+        }
+    }
+}
+
+/// A handle to the shutdown system.
+#[derive(Debug)]
+pub struct ShutdownHandle {
+    /// Sender to request a shutdown.
+    sender: broadcast::Sender<()>,
+    /// Receiver to be notified of shutdowns.
+    receiver: broadcast::Receiver<()>,
+    /// Guard for task completion.
+    ///
+    /// See: <https://tokio.rs/tokio/topics/shutdown#waiting-for-things-to-finish-shutting-down>
+    guard: mpsc::Sender<()>,
+    /// The tasks being run.
+    handles: Handles,
+}
+
+impl Clone for ShutdownHandle {
+    fn clone(&self) -> Self {
+        let sender = self.sender.clone();
+        let receiver = sender.subscribe();
+        Self {
+            sender,
+            receiver,
+            guard: self.guard.clone(),
+            handles: self.handles.clone(),
+        }
+    }
+}
+
+impl ShutdownHandle {
+    /// Wait until a shutdown is requested.
+    pub async fn on_shutdown_requested(&mut self) -> Result<(), broadcast::error::RecvError> {
+        self.receiver.recv().await
+    }
+
+    /// Check if a shutdown has been requested; if so, return a [`ShutdownError`].
+    ///
+    /// Otherwise, return `Ok(())`.
+    pub fn error_if_shutdown_requested(&mut self) -> miette::Result<()> {
+        match self.receiver.try_recv() {
+            Ok(()) | Err(broadcast::error::TryRecvError::Lagged(_)) => Err(ShutdownError.into()),
+            Err(broadcast::error::TryRecvError::Empty) => {
+                // No shutdown requested.
+                Ok(())
+            }
+            err @ Err(broadcast::error::TryRecvError::Closed) => err.into_diagnostic(),
+        }
+    }
+
+    /// Request a shutdown.
+    pub fn request_shutdown(&self) -> Result<(), broadcast::error::SendError<()>> {
+        self.sender.send(()).map(|_| ())
+    }
+
+    /// Spawn a new task under this handle.
+    pub async fn spawn<F, Fut>(&mut self, name: String, make_task: F)
+    where
+        F: FnOnce(ShutdownHandle) -> Fut,
+        Fut: Future<Output = miette::Result<()>> + Send + 'static,
+    {
+        let handle = tokio::task::spawn(make_task(self.clone()));
+        self.handles
+            .push(Task::new(name, handle, self.sender.clone()))
+            .await;
+    }
+}
+
+/// A task being managed by a [`ShutdownManager`].
+#[derive(Debug)]
+struct Task {
+    /// The name of the running task.
+    name: String,
+    /// A handle for remotely cancelling the task.
+    abort_handle: AbortHandle,
+    /// A receiver for the task's return value.
+    receiver: oneshot::Receiver<Option<miette::Report>>,
+    /// A handle for the manager which runs asynchronously and requests a shutdown if the task
+    /// errors.
+    #[allow(dead_code)]
+    manager_handle: JoinHandle<()>,
+}
+
+impl Task {
+    /// Create a new task with the given name and handle.
+    fn new(
+        name: String,
+        handle: JoinHandle<miette::Result<()>>,
+        request_shutdown: broadcast::Sender<()>,
+    ) -> Self {
+        let abort_handle = handle.abort_handle();
+        let (sender, receiver) = oneshot::channel();
+        let manager_handle = tokio::task::spawn(manage_handle(
+            name.clone(),
+            handle,
+            request_shutdown,
+            sender,
+        ));
+        Self {
+            name,
+            abort_handle,
+            manager_handle,
+            receiver,
+        }
+    }
+
+    /// Cancel the task.
+    fn cancel(&self) {
+        self.abort_handle.abort();
+    }
+
+    /// Check if the task is finished.
+    fn is_finished(&self) -> bool {
+        self.abort_handle.is_finished()
+    }
+
+    /// Wait for the task to complete and get its name and an error message if it fails.
+    async fn into_result(self) -> miette::Result<Option<(String, miette::ErrReport)>> {
+        let maybe_error = self.receiver.await.into_diagnostic()?;
+        Ok(maybe_error.map(|err| (self.name, err)))
+    }
+}
+
+/// Manage a task, requesting a shutdown if it fails and notifying the given sender of any errors.
+async fn manage_handle(
+    name: String,
+    handle: JoinHandle<miette::Result<()>>,
+    request_shutdown: broadcast::Sender<()>,
+    sender: oneshot::Sender<Option<miette::Report>>,
+) {
+    let mut ret = None;
+    match handle.await {
+        Ok(Ok(())) => {
+            tracing::debug!(task = name, "Task completed successfully");
+        }
+        Ok(Err(err)) => {
+            if err.downcast_ref::<ShutdownError>().is_some() {
+                tracing::debug!(task = name, "Task shut down gracefully");
+            } else {
+                tracing::debug!(task = name, "Task failed: {err:?}");
+                ret = Some(err);
+            }
+        }
+        Err(err) => {
+            if err.is_cancelled() {
+                tracing::debug!(task = name, "Task cancelled");
+            } else {
+                tracing::debug!(task = name, "Task panicked: {err}");
+                ret = Some(miette!("{err}"));
+            }
+        }
+    }
+    if ret.is_some() {
+        let _ = request_shutdown.send(());
+    }
+    let _ = sender.send(ret);
+}
+
+/// A shutdown was requested.
+///
+/// This error can be returned to indicate that the task failed to finish its computation due to a
+/// shutdown being requested. Unlike other errors, this won't be displayed as a failure in the
+/// [`ShutdownManager::wait_for_shutdown`] return value.
+#[derive(Debug, Clone, Copy)]
+pub struct ShutdownError;
+
+impl ShutdownError {
+    /// Get a [`miette::Report`] of a [`ShutdownError`].
+    pub fn as_report() -> miette::Report {
+        miette::Report::msg(Self)
+    }
+}
+
+impl Error for ShutdownError {}
+
+impl Display for ShutdownError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Shutdown requested")
+    }
+}
+
+impl miette::Diagnostic for ShutdownError {}

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -111,9 +111,9 @@ impl ShutdownManager {
                 _ = self.guard_receiver.recv() => {
                     tracing::debug!("All tasks finished");
                 }
-                _ = tokio::time::sleep(self.timeout) => {
-                    tracing::debug!("Graceful shutdown timed out");
-                }
+                // _ = tokio::time::sleep(self.timeout) => {
+                    // tracing::debug!("Graceful shutdown timed out");
+                // }
             }
         }
         // Note any unfinished tasks, cancel everything, and check the return values.

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -61,6 +61,7 @@ impl WatcherOpts {
 
 /// A [`notify`] watcher which waits for file changes and sends reload events to the contained
 /// `ghci` session.
+#[instrument(level = "debug", skip_all)]
 pub async fn run_watcher(
     handle: ShutdownHandle,
     ghci_sender: mpsc::Sender<GhciEvent>,

--- a/test-harness/src/fs.rs
+++ b/test-harness/src/fs.rs
@@ -45,9 +45,11 @@ pub async fn write(path: impl AsRef<Path> + Debug, data: impl AsRef<[u8]>) -> mi
         create_dir(parent).await?;
     }
 
-    // Load-bearing sleep! If this is removed, some writes aren't detected some of the time.
-    // Comment it out and run `cargo nextest run` in a loop to see what I mean.
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    if crate::internal::GHCIWATCH_PROCESS.with(|option| option.borrow().is_some()) {
+        // Load-bearing sleep! If this is removed, some writes aren't detected some of the time.
+        // Comment it out and run `cargo nextest run` in a loop to see what I mean.
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
 
     tokio::fs::write(path, data)
         .await

--- a/test-harness/src/lib.rs
+++ b/test-harness/src/lib.rs
@@ -2,6 +2,8 @@
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 
+pub use serde_json::Value as JsonValue;
+
 mod tracing_json;
 pub use tracing_json::Event;
 

--- a/test-harness/src/matcher/base_matcher.rs
+++ b/test-harness/src/matcher/base_matcher.rs
@@ -144,24 +144,7 @@ impl BaseMatcher {
 
     /// Match when the filesystem worker starts.
     pub fn watcher_started() -> Self {
-        // `watchexec` sends a few events when it starts up:
-        //
-        // DEBUG watchexec::watchexec: handing over main task handle
-        // DEBUG watchexec::watchexec: starting main task
-        // DEBUG watchexec::watchexec: spawning subtask {subtask="action"}
-        // DEBUG watchexec::watchexec: spawning subtask {subtask="fs"}
-        // DEBUG watchexec::watchexec: spawning subtask {subtask="signal"}
-        // DEBUG watchexec::watchexec: spawning subtask {subtask="keyboard"}
-        // DEBUG watchexec::fs: launching filesystem worker
-        // DEBUG watchexec::watchexec: spawning subtask {subtask="error_hook"}
-        // DEBUG watchexec::fs: creating new watcher {kind="Poll(100ms)"}
-        // DEBUG watchexec::signal: launching unix signal worker
-        // DEBUG watchexec::fs: applying changes to the watcher {to_drop="[]", to_watch="[WatchedPath(\"src\")]"}
-        //
-        // "launching filesystem worker" is tempting, but the phrasing implies the event is emitted
-        // _before_ the filesystem worker is started (hence it is not yet ready to notice file
-        // events). Therefore, we wait for "applying changes to the watcher".
-        Self::message("applying changes to the watcher").in_module("watchexec::fs")
+        Self::message("^notify watcher started$").in_module("ghciwatch::watcher")
     }
 
     /// Match when `ghci` reloads.

--- a/tests/data/simple/Makefile
+++ b/tests/data/simple/Makefile
@@ -1,6 +1,21 @@
-CABAL = cabal \
-		--offline \
-		$(if $(GHC), --with-compiler=$(GHC))
+CABAL_OPTS ?=
+CABAL ?= cabal \
+	--offline \
+	$(if $(GHC), --with-compiler=$(GHC)) \
+	$(CABAL_OPTS)
+
+CABAL_REPL ?= $(CABAL) \
+	--repl-option -fdiagnostics-color=always \
+	-flocal-dev v2-repl lib:test-dev
+
+GHCIWATCH_OPTS ?=
+GHCIWATCH ?= ../../../target/release/ghciwatch \
+	--command "$(CABAL_REPL)" \
+	--before-startup-shell "make my-simple-package.cabal" \
+	--watch src \
+	--watch test \
+	--watch test-main \
+	$(GHCIWATCH_OPTS)
 
 my-simple-package.cabal: package.yaml
 	hpack .
@@ -11,8 +26,12 @@ test: my-simple-package.cabal
 	$(CABAL) test
 	$(CABAL) -flocal-dev build
 	$(CABAL) -flocal-dev test
-	echo ":quit" | $(CABAL) -flocal-dev repl lib:test-dev
+	echo ":quit" | $(CABAL_REPL)
 
 .PHONY: ghci
 ghci: my-simple-package.cabal
-	$(CABAL) -flocal-dev repl lib:test-dev
+	$(CABAL_REPL)
+
+.PHONY: ghciwatch
+ghciwatch:
+	$(GHCIWATCH)

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -22,7 +22,7 @@ async fn can_eval_commands() {
     let module_path = session.path(module_path);
 
     session
-        .wait_until_started()
+        .wait_until_ready()
         .await
         .expect("ghciwatch didn't start in time");
 

--- a/tests/reload.rs
+++ b/tests/reload.rs
@@ -32,11 +32,7 @@ async fn can_reload() {
         .await
         .expect("ghciwatch reloads on changes");
     session
-        .wait_for_log(
-            BaseMatcher::span_close()
-                .in_module("ghciwatch::ghci")
-                .in_spans(["on_action", "reload"]),
-        )
+        .wait_for_log(BaseMatcher::reload_completes())
         .await
         .expect("ghciwatch finishes reloading");
 }

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -1,0 +1,67 @@
+use nix::sys::signal;
+use nix::sys::signal::Signal;
+use nix::unistd::Pid;
+use test_harness::test;
+use test_harness::BaseMatcher;
+use test_harness::GhciWatch;
+use test_harness::JsonValue;
+
+/// Test that `ghciwatch` can gracefully shutdown on Ctrl-C.
+#[test]
+async fn can_shutdown_gracefully() {
+    let mut session = GhciWatch::new("tests/data/simple")
+        .await
+        .expect("ghciwatch starts");
+    session
+        .wait_until_ready()
+        .await
+        .expect("ghciwatch loads ghci");
+
+    signal::kill(Pid::from_raw(session.pid() as i32), Signal::SIGINT)
+        .expect("Failed to send Ctrl-C to ghciwatch");
+
+    session
+        .wait_for_log("^All tasks completed successfully$")
+        .await
+        .unwrap();
+}
+
+/// Test that `ghciwatch` can gracefully shutdown when the `ghci` process is unexpectedly killed.
+#[test]
+async fn can_shutdown_gracefully_when_ghci_killed() {
+    let mut session = GhciWatch::new("tests/data/simple")
+        .await
+        .expect("ghciwatch starts");
+
+    let event = session
+        .wait_for_log(BaseMatcher::message("^Started ghci$"))
+        .await
+        .expect("ghciwatch starts ghci");
+    let pid: i32 = match event.fields.get("pid").unwrap() {
+        JsonValue::Number(pid) => pid,
+        value => {
+            panic!("pid field has wrong type: {value:?}");
+        }
+    }
+    .as_i64()
+    .expect("pid is i64")
+    .try_into()
+    .expect("pid is i32");
+
+    session
+        .wait_until_ready()
+        .await
+        .expect("ghciwatch loads ghci");
+
+    signal::kill(Pid::from_raw(pid), Signal::SIGKILL).expect("Failed to kill ghci");
+
+    session
+        .wait_for_log("^ghci exited:")
+        .await
+        .expect("ghci exits");
+    session.wait_for_log("^Shutdown requested$").await.unwrap();
+    session
+        .wait_for_log("^All tasks completed successfully$")
+        .await
+        .unwrap();
+}

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -24,6 +24,9 @@ async fn can_shutdown_gracefully() {
         .wait_for_log("^All tasks completed successfully$")
         .await
         .unwrap();
+
+    let status = session.wait_until_exit().await.unwrap();
+    assert!(status.success(), "ghciwatch exits successfully");
 }
 
 /// Test that `ghciwatch` can gracefully shutdown when the `ghci` process is unexpectedly killed.


### PR DESCRIPTION
This PR switches `ghcid-ng` from the `watchexec` crate to using the `notify` crate directly. (This is what `watchexec` uses under the hood.) `watchexec` is very nice, but it's largely designed around the needs of the `watchexec(1)` binary (namely running commands when files change). Using `notify` makes the code much nicer.

One of the things that `watchexec` provides that `notify` doesn't is shutting down when Ctrl-C is pressed. Most of the rest of the changes are about implementing this graceful shutdown procedure.

See [the “Graceful Shutdown” section in the Tokio book](https://tokio.rs/tokio/topics/shutdown) for more details.

Originally I implemented this with [the `tokio-graceful-shutdown` crate](https://docs.rs/tokio-graceful-shutdown/latest/tokio_graceful_shutdown/), but it turned out to be missing some features I wanted. (In particular, performing a graceful shutdown when Ctrl-C is pressed and then performing a hard shutdown if Ctrl-C is pressed again.) Fortunately, implementing the subset of features we need wasn't too hard.