### PR TITLE
Add matcher combinators

### DIFF
--- a/src/event_filter.rs
+++ b/src/event_filter.rs
@@ -98,7 +98,7 @@ pub fn file_events_from_action(action: &Action) -> miette::Result<Vec<FileEvent>
         for tag in event.tags.iter() {
             if let Tag::Path { path, .. } = tag {
                 let path = path.to_owned().try_into().into_diagnostic()?;
-                let entry = events_by_path.entry(path).or_insert_with(Vec::new);
+                let entry = events_by_path.entry(path).or_default();
                 entry.push(event);
                 // No need to look at the rest of the tags.
                 break;

--- a/src/normal_path.rs
+++ b/src/normal_path.rs
@@ -88,7 +88,7 @@ impl Eq for NormalPath {}
 
 impl PartialOrd for NormalPath {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        PartialOrd::partial_cmp(&self.normal, &other.normal)
+        Some(self.cmp(other))
     }
 }
 

--- a/test-harness/src/checkpoint.rs
+++ b/test-harness/src/checkpoint.rs
@@ -1,0 +1,104 @@
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::ops::Range;
+use std::ops::RangeFrom;
+use std::ops::RangeFull;
+use std::ops::RangeInclusive;
+use std::ops::RangeTo;
+use std::ops::RangeToInclusive;
+use std::slice::SliceIndex;
+
+use crate::Event;
+
+/// A checkpoint in a `ghciwatch` run.
+///
+/// [`crate::GhciWatch`] provides methods for asserting that events are logged, or waiting for
+/// events to be logged in the future.
+///
+/// To avoid searching thousands of log events for each assertion, and to provide greater
+/// granularity for assertions, you can additionally assert that events are logged between
+/// particular checkpoints.
+///
+/// Checkpoints can be constructed with [`crate::GhciWatch::first_checkpoint`],
+/// [`crate::GhciWatch::current_checkpoint`], and [`crate::GhciWatch::checkpoint`].
+#[derive(Debug, Clone, Copy)]
+pub struct Checkpoint(pub(crate) usize);
+
+impl Checkpoint {
+    /// Convert this checkpoint into an index.
+    pub fn into_index(self) -> usize {
+        self.0
+    }
+}
+
+impl Display for Checkpoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A type that can be used to index a set of checkpoints.
+pub trait CheckpointIndex: Clone {
+    /// The resulting index type.
+    type Index: SliceIndex<[Vec<Event>], Output = [Vec<Event>]> + Debug;
+
+    /// Convert the value into an index.
+    fn into_index(self) -> Self::Index;
+}
+
+impl CheckpointIndex for Checkpoint {
+    type Index = RangeInclusive<usize>;
+
+    fn into_index(self) -> Self::Index {
+        let index = self.into_index();
+        index..=index
+    }
+}
+
+impl CheckpointIndex for Range<Checkpoint> {
+    type Index = Range<usize>;
+
+    fn into_index(self) -> Self::Index {
+        self.start.into_index()..self.end.into_index()
+    }
+}
+
+impl CheckpointIndex for RangeFrom<Checkpoint> {
+    type Index = RangeFrom<usize>;
+
+    fn into_index(self) -> Self::Index {
+        self.start.into_index()..
+    }
+}
+
+impl CheckpointIndex for RangeFull {
+    type Index = RangeFull;
+
+    fn into_index(self) -> Self::Index {
+        self
+    }
+}
+
+impl CheckpointIndex for RangeInclusive<Checkpoint> {
+    type Index = RangeInclusive<usize>;
+
+    fn into_index(self) -> Self::Index {
+        self.start().into_index()..=self.end().into_index()
+    }
+}
+
+impl CheckpointIndex for RangeTo<Checkpoint> {
+    type Index = RangeTo<usize>;
+
+    fn into_index(self) -> Self::Index {
+        ..self.end.into_index()
+    }
+}
+
+impl CheckpointIndex for RangeToInclusive<Checkpoint> {
+    type Index = RangeToInclusive<usize>;
+
+    fn into_index(self) -> Self::Index {
+        ..=self.end.into_index()
+    }
+}

--- a/test-harness/src/checkpoint.rs
+++ b/test-harness/src/checkpoint.rs
@@ -25,8 +25,8 @@ use crate::Event;
 pub struct Checkpoint(pub(crate) usize);
 
 impl Checkpoint {
-    /// Convert this checkpoint into an index.
-    pub fn into_index(self) -> usize {
+    /// Get the underlying `usize` from this checkpoint.
+    pub fn into_inner(self) -> usize {
         self.0
     }
 }
@@ -50,7 +50,7 @@ impl CheckpointIndex for Checkpoint {
     type Index = RangeInclusive<usize>;
 
     fn into_index(self) -> Self::Index {
-        let index = self.into_index();
+        let index = self.into_inner();
         index..=index
     }
 }
@@ -59,7 +59,7 @@ impl CheckpointIndex for Range<Checkpoint> {
     type Index = Range<usize>;
 
     fn into_index(self) -> Self::Index {
-        self.start.into_index()..self.end.into_index()
+        self.start.into_inner()..self.end.into_inner()
     }
 }
 
@@ -67,7 +67,7 @@ impl CheckpointIndex for RangeFrom<Checkpoint> {
     type Index = RangeFrom<usize>;
 
     fn into_index(self) -> Self::Index {
-        self.start.into_index()..
+        self.start.into_inner()..
     }
 }
 
@@ -83,7 +83,7 @@ impl CheckpointIndex for RangeInclusive<Checkpoint> {
     type Index = RangeInclusive<usize>;
 
     fn into_index(self) -> Self::Index {
-        self.start().into_index()..=self.end().into_index()
+        self.start().into_inner()..=self.end().into_inner()
     }
 }
 
@@ -91,7 +91,7 @@ impl CheckpointIndex for RangeTo<Checkpoint> {
     type Index = RangeTo<usize>;
 
     fn into_index(self) -> Self::Index {
-        ..self.end.into_index()
+        ..self.end.into_inner()
     }
 }
 
@@ -99,6 +99,6 @@ impl CheckpointIndex for RangeToInclusive<Checkpoint> {
     type Index = RangeToInclusive<usize>;
 
     fn into_index(self) -> Self::Index {
-        ..=self.end.into_index()
+        ..=self.end.into_inner()
     }
 }

--- a/test-harness/src/ghciwatch.rs
+++ b/test-harness/src/ghciwatch.rs
@@ -428,9 +428,8 @@ impl GhciWatch {
     /// Wait until `ghciwatch` reloads the `ghci` session due to changed modules.
     pub async fn wait_until_reload(&mut self) -> miette::Result<()> {
         // TODO: It would be nice to verify which modules are changed.
-        self.wait_for_log(BaseMatcher::ghci_reload())
-            .await
-            .map(|_| ())
+        self.wait_for_log(BaseMatcher::ghci_reload()).await?;
+        Ok(())
     }
 
     /// Wait until `ghciwatch` adds new modules to the `ghci` session.

--- a/test-harness/src/ghciwatch.rs
+++ b/test-harness/src/ghciwatch.rs
@@ -13,9 +13,10 @@ use miette::IntoDiagnostic;
 use tokio::process::Command;
 
 use crate::matcher::Matcher;
-use crate::matcher::OptionMatcher;
 use crate::tracing_reader::TracingReader;
 use crate::BaseMatcher;
+use crate::Checkpoint;
+use crate::CheckpointIndex;
 use crate::Event;
 use crate::GhcVersion;
 use crate::IntoMatcher;
@@ -30,6 +31,8 @@ pub struct GhciWatchBuilder {
     args: Vec<OsString>,
     #[allow(clippy::type_complexity)]
     before_start: Option<Box<dyn FnOnce(PathBuf) -> BoxFuture<'static, miette::Result<()>> + Send>>,
+    default_timeout: Duration,
+    startup_timeout: Duration,
 }
 
 impl GhciWatchBuilder {
@@ -39,6 +42,8 @@ impl GhciWatchBuilder {
             project_directory: project_directory.as_ref().to_owned(),
             args: Default::default(),
             before_start: None,
+            default_timeout: Duration::from_secs(10),
+            startup_timeout: Duration::from_secs(60),
         }
     }
 
@@ -65,6 +70,24 @@ impl GhciWatchBuilder {
         self
     }
 
+    /// Set the default timeout to wait for log messages in [`GhciWatch::wait_for_log`],
+    /// [`GhciWatch::assert_logged_or_wait`], and similar.
+    ///
+    /// The timeout defaults to 10 seconds.
+    pub fn with_default_timeout(mut self, default_timeout: Duration) -> Self {
+        self.default_timeout = default_timeout;
+        self
+    }
+
+    /// Set the default timeout to wait for `ghci` to start up in
+    /// [`GhciWatch::wait_until_started`] and [`GhciWatch::wait_until_ready`].
+    ///
+    /// The timeout defaults to 60 seconds.
+    pub fn with_startup_timeout(mut self, startup_timeout: Duration) -> Self {
+        self.startup_timeout = startup_timeout;
+        self
+    }
+
     /// Start `ghciwatch`.
     pub async fn start(self) -> miette::Result<GhciWatch> {
         GhciWatch::from_builder(self).await
@@ -80,8 +103,17 @@ pub struct GhciWatch {
     cwd: PathBuf,
     /// A stream of tracing events from `ghciwatch`.
     tracing_reader: TracingReader,
+    /// All logged events read so far.
+    ///
+    /// TODO: Make this a `Vec<Vec<Event>>` with "checkpoints" and allow searching in given
+    /// checkpoint ranges.
+    events: Vec<Vec<Event>>,
     /// The major version of GHC this test is running under.
     ghc_version: GhcVersion,
+    /// The default timeout for waiting for log messages.
+    default_timeout: Duration,
+    /// The timeout for waiting for `ghci to finish starting up.
+    startup_timeout: Duration,
 }
 
 impl GhciWatch {
@@ -156,7 +188,7 @@ impl GhciWatch {
 
         // Wait for `ghciwatch` to create the `log_path`
         let creates_log_path =
-            tokio::time::timeout(Duration::from_secs(10), crate::fs::wait_for_path(&log_path));
+            tokio::time::timeout(builder.default_timeout, crate::fs::wait_for_path(&log_path));
         tokio::select! {
             child_result = child.wait() => {
                 return match child_result {
@@ -180,10 +212,18 @@ impl GhciWatch {
 
         let tracing_reader = TracingReader::new(log_path.clone()).await?;
 
+        // Most tests won't use checkpoints, so we'll only have a couple checkpoint slots
+        // and many event slots in the first checkpoint chunk.
+        let mut events = Vec::with_capacity(8);
+        events.push(Vec::with_capacity(1024));
+
         Ok(Self {
             cwd,
             tracing_reader,
+            events,
             ghc_version,
+            default_timeout: builder.default_timeout,
+            startup_timeout: builder.startup_timeout,
         })
     }
 
@@ -192,33 +232,109 @@ impl GhciWatch {
         GhciWatchBuilder::new(project_directory).start().await
     }
 
-    /// Wait until a matching log event is found.
+    /// Get the first [`Checkpoint`].
     ///
-    /// If `negative_matcher` is given, no log events may match it until an event matching the
-    /// regular `matcher` is found.
+    /// There is always an initial checkpoint which events are logged into before other
+    /// checkpoints are created.
+    ///
+    /// Note that `first_checkpoint()..=current_checkpoint()` is equivalent to `..`.
+    pub fn first_checkpoint(&self) -> Checkpoint {
+        Checkpoint(0)
+    }
+
+    /// Get the current [`Checkpoint`].
+    ///
+    /// Events read by [`GhciWatch::wait_for_log_with_timeout`] and friends will add events to
+    /// this checkpoint.
+    pub fn current_checkpoint(&self) -> Checkpoint {
+        Checkpoint(self.events.len() - 1)
+    }
+
+    /// Create and return a new [`Checkpoint`].
+    ///
+    /// New log events will be stored in this checkpoint.
+    ///
+    /// Later, you can check for log events in checkpoints with
+    /// [`Self::assert_logged_in_checkpoint`] and friends.
+    pub fn checkpoint(&mut self) -> Checkpoint {
+        self.events.push(Vec::with_capacity(512));
+        self.current_checkpoint()
+    }
+
+    /// Get the `Vec` of events since the last checkpoint.
+    fn current_chunk_mut(&mut self) -> &mut Vec<Event> {
+        self.events
+            .last_mut()
+            .expect("There is always an initial checkpoint")
+    }
+
+    /// Get an iterator over the events in the given checkpoints.
+    ///
+    /// The `index` can be an individual [`Checkpoint`] or any [`std::ops::Range`] of checkpoints.
+    fn events_in_checkpoints(&self, index: impl CheckpointIndex) -> impl Iterator<Item = &Event> {
+        self.events[index.into_index()].iter().flatten()
+    }
+
+    /// Read an event from the `ghciwatch` session.
+    async fn read_event(&mut self) -> miette::Result<&Event> {
+        let event = self.tracing_reader.next_event().await?;
+        let chunk = self.current_chunk_mut();
+        chunk.push(event);
+        Ok(chunk.last().expect("We just inserted this event"))
+    }
+
+    /// Assert that a matching event was logged in one of the given `checkpoints`.
+    pub fn assert_logged_in_checkpoint(
+        &self,
+        checkpoints: impl CheckpointIndex,
+        matcher: impl IntoMatcher,
+    ) -> miette::Result<&Event> {
+        let mut matcher = matcher.into_matcher()?;
+        for event in self.events_in_checkpoints(checkpoints.clone()) {
+            if matcher.matches(event)? {
+                return Ok(event);
+            }
+        }
+
+        Err(miette!(
+            "No log message matching {matcher} found in checkpoint {:?}",
+            checkpoints.into_index()
+        ))
+    }
+
+    /// Assert that a matching event was logged since the last [`Checkpoint`].
+    pub fn assert_logged(&self, matcher: impl IntoMatcher) -> miette::Result<&Event> {
+        self.assert_logged_in_checkpoint(self.current_checkpoint(), matcher)
+    }
+
+    /// Match a log message in the given checkpoints or wait until a matching log event is
+    /// found.
+    ///
+    /// If `checkpoints` is `None`, do not check the `matcher` against any previously logged
+    /// events.
     ///
     /// Errors if waiting for the event takes longer than the given `timeout`.
-    pub async fn assert_logged_with_timeout<M: Matcher>(
+    pub async fn wait_for_log_with_timeout<M: IntoMatcher, C: CheckpointIndex>(
         &mut self,
-        mut negative_matcher: OptionMatcher<M>,
-        matcher: impl IntoMatcher,
+        matcher: M,
+        checkpoints: Option<C>,
         timeout_duration: Duration,
     ) -> miette::Result<Event> {
         let mut matcher = matcher.into_matcher()?;
 
+        // First check if it was logged in `checkpoints`.
+        if let Some(checkpoints) = checkpoints {
+            if let Ok(event) = self.assert_logged_in_checkpoint(checkpoints, &mut matcher) {
+                return Ok(event.clone());
+            }
+        }
+
+        // Otherwise, wait for a log message.
         match tokio::time::timeout(timeout_duration, async {
             loop {
-                match self.tracing_reader.next_event().await {
-                    Err(err) => {
-                        return Err(err);
-                    }
-                    Ok(event) => {
-                        if matcher.matches(&event)? {
-                            return Ok(event);
-                        } else if negative_matcher.matches(&event)? {
-                            return Err(miette!("Found a log event matching {negative_matcher}"));
-                        }
-                    }
+                let event = self.read_event().await?;
+                if matcher.matches(event)? {
+                    return Ok(event.clone());
                 }
             }
         })
@@ -227,63 +343,92 @@ impl GhciWatch {
             Ok(Ok(event)) => Ok(event),
             Ok(Err(err)) => Err(err),
             Err(_) => Err(miette!(
-                "Waiting for a log message matching {matcher} timed out after {timeout_duration:.2?}"
+                "Waiting for a log message matching {matcher} \
+                 timed out after {timeout_duration:.2?}"
             )),
         }
     }
 
-    /// Wait until a matching log event is found, with a default 10-second timeout.
-    pub async fn assert_logged(&mut self, matcher: impl IntoMatcher) -> miette::Result<Event> {
-        self.assert_logged_with_timeout(OptionMatcher::none(), matcher, Duration::from_secs(10))
+    /// Assert that a message matching `matcher` has been logged in the given [`Checkpoint`]s or
+    /// wait for the `default_timeout` for a matching message to be logged.
+    pub async fn assert_logged_in_checkpoint_or_wait(
+        &mut self,
+        checkpoints: impl CheckpointIndex,
+        matcher: impl IntoMatcher,
+    ) -> miette::Result<Event> {
+        self.wait_for_log_with_timeout(matcher, Some(checkpoints), self.default_timeout)
             .await
     }
 
-    /// Wait until a matching log event is found, with a default 10-second timeout.
-    ///
-    /// Error if a log event matching `negative_matcher` is found before an event matching
-    /// `matcher`.
-    pub async fn assert_not_logged(
+    /// Assert that a message matching `matcher` has been logged in the most recent [`Checkpoint`]
+    /// or wait for the `default_timeout` for a matching message to be logged.
+    pub async fn assert_logged_or_wait(
         &mut self,
-        negative_matcher: impl IntoMatcher,
         matcher: impl IntoMatcher,
     ) -> miette::Result<Event> {
-        self.assert_logged_with_timeout(
-            OptionMatcher::some(negative_matcher.into_matcher()?),
+        self.wait_for_log_with_timeout(
             matcher,
-            Duration::from_secs(10),
+            Some(self.current_checkpoint()),
+            self.default_timeout,
         )
         .await
     }
 
-    /// Wait until `ghcidwatch` completes its initial load and is ready to receive file events.
-    pub async fn wait_until_started(&mut self) -> miette::Result<Event> {
-        self.assert_logged_with_timeout(
-            OptionMatcher::none(),
+    /// Wait until a matching log event is found with the `default_timeout`.
+    pub async fn wait_for_log(&mut self, matcher: impl IntoMatcher) -> miette::Result<Event> {
+        self.wait_for_log_with_timeout(matcher, None::<Checkpoint>, self.default_timeout)
+            .await
+    }
+
+    /// Wait until `ghciwatch` completes its initial load.
+    ///
+    /// Returns immediately if `ghciwatch` has already completed its initial load in the current
+    /// checkpoint.
+    pub async fn wait_until_started(&mut self) -> miette::Result<()> {
+        self.wait_for_log_with_timeout(
             BaseMatcher::ghci_started(),
-            Duration::from_secs(60),
+            Some(self.current_checkpoint()),
+            self.startup_timeout,
         )
         .await
-        .wrap_err("ghciwatch didn't start in time")
+        .wrap_err("ghciwatch didn't start in time")?;
+        Ok(())
     }
 
     /// Wait until `ghciwatch` is ready to receive file events.
-    pub async fn wait_until_watcher_started(&mut self) -> miette::Result<Event> {
-        self.assert_logged(BaseMatcher::watcher_started())
-            .await
-            .wrap_err("notify watcher didn't start in time")
+    ///
+    /// Returns immediately if `ghciwatch` has already become ready to receive file events in the
+    /// current checkpoint.
+    pub async fn wait_until_watcher_started(&mut self) -> miette::Result<()> {
+        self.wait_for_log_with_timeout(
+            BaseMatcher::watcher_started(),
+            Some(self.current_checkpoint()),
+            self.default_timeout,
+        )
+        .await
+        .wrap_err("notify watcher didn't start in time")?;
+        Ok(())
     }
 
     /// Wait until `ghciwatch` completes its initial load and is ready to receive file events.
+    ///
+    /// Returns immediately if `ghciwatch` has already completed its inital load and become ready to
+    /// receive file events in the current checkpoint.
     pub async fn wait_until_ready(&mut self) -> miette::Result<()> {
-        self.wait_until_started().await?;
-        self.wait_until_watcher_started().await?;
+        self.wait_for_log_with_timeout(
+            BaseMatcher::ghci_started().and(BaseMatcher::watcher_started()),
+            Some(self.current_checkpoint()),
+            self.startup_timeout,
+        )
+        .await
+        .wrap_err("ghciwatch didn't start in time")?;
         Ok(())
     }
 
     /// Wait until `ghciwatch` reloads the `ghci` session due to changed modules.
     pub async fn wait_until_reload(&mut self) -> miette::Result<()> {
         // TODO: It would be nice to verify which modules are changed.
-        self.assert_logged(BaseMatcher::ghci_reload())
+        self.wait_for_log(BaseMatcher::ghci_reload())
             .await
             .map(|_| ())
     }
@@ -291,17 +436,15 @@ impl GhciWatch {
     /// Wait until `ghciwatch` adds new modules to the `ghci` session.
     pub async fn wait_until_add(&mut self) -> miette::Result<()> {
         // TODO: It would be nice to verify which modules are being added.
-        self.assert_logged(BaseMatcher::ghci_add())
-            .await
-            .map(|_| ())
+        self.wait_for_log(BaseMatcher::ghci_add()).await?;
+        Ok(())
     }
 
     /// Wait until `ghciwatch` restarts the `ghci` session.
     pub async fn wait_until_restart(&mut self) -> miette::Result<()> {
         // TODO: It would be nice to verify which modules have been deleted/moved.
-        self.assert_logged(BaseMatcher::ghci_restart())
-            .await
-            .map(|_| ())
+        self.wait_for_log(BaseMatcher::ghci_restart()).await?;
+        Ok(())
     }
 
     /// Get a path relative to the project root.

--- a/test-harness/src/lib.rs
+++ b/test-harness/src/lib.rs
@@ -8,8 +8,10 @@ pub use tracing_json::Event;
 mod tracing_reader;
 
 mod matcher;
+pub use matcher::BaseMatcher;
 pub use matcher::IntoMatcher;
 pub use matcher::Matcher;
+pub use matcher::OrMatcher;
 
 pub mod fs;
 

--- a/test-harness/src/lib.rs
+++ b/test-harness/src/lib.rs
@@ -27,3 +27,7 @@ pub use ghciwatch::GhciWatchBuilder;
 
 mod ghc_version;
 pub use ghc_version::GhcVersion;
+
+mod checkpoint;
+pub use checkpoint::Checkpoint;
+pub use checkpoint::CheckpointIndex;

--- a/test-harness/src/matcher/and_matcher.rs
+++ b/test-harness/src/matcher/and_matcher.rs
@@ -1,0 +1,69 @@
+use std::fmt::Display;
+
+use crate::Event;
+use crate::Matcher;
+
+/// A [`Matcher`] that can match either of two other matchers.
+pub struct AndMatcher<A, B>(pub A, pub B);
+
+impl<A, B> Display for AndMatcher<A, B>
+where
+    A: Display,
+    B: Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} and {}", self.0, self.1)
+    }
+}
+
+impl<A, B> Matcher for AndMatcher<A, B>
+where
+    A: Display + Matcher,
+    B: Display + Matcher,
+{
+    fn matches(&mut self, event: &Event) -> miette::Result<bool> {
+        // There may be some overlap in the events these matchers require to complete, so
+        // we eagerly evaluate both matchers before combining the boolean result.
+        let match_a = self.0.matches(event)?;
+        let match_b = self.1.matches(event)?;
+        Ok(match_a && match_b)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tracing::Level;
+
+    use crate::tracing_json::Span;
+    use crate::IntoMatcher;
+
+    use super::*;
+
+    #[test]
+    fn test_and_matcher() {
+        let mut matcher = "puppy".into_matcher().unwrap().and("doggy").unwrap();
+        let event = Event {
+            message: "puppy".to_owned(),
+            timestamp: "2023-08-25T22:14:30.067641Z".to_owned(),
+            level: Level::INFO,
+            fields: Default::default(),
+            target: "ghciwatch::ghci".to_owned(),
+            span: Some(Span {
+                name: "ghci".to_owned(),
+                rest: Default::default(),
+            }),
+            spans: vec![Span {
+                name: "ghci".to_owned(),
+                rest: Default::default(),
+            }],
+        };
+
+        assert!(!matcher.matches(&event).unwrap());
+        assert!(matcher
+            .matches(&Event {
+                message: "doggy".to_owned(),
+                ..event
+            })
+            .unwrap());
+    }
+}

--- a/test-harness/src/matcher/and_matcher.rs
+++ b/test-harness/src/matcher/and_matcher.rs
@@ -41,7 +41,10 @@ mod tests {
 
     #[test]
     fn test_and_matcher() {
-        let mut matcher = "puppy".into_matcher().unwrap().and("doggy").unwrap();
+        let mut matcher = "puppy"
+            .into_matcher()
+            .unwrap()
+            .and("doggy".into_matcher().unwrap());
         let event = Event {
             message: "puppy".to_owned(),
             timestamp: "2023-08-25T22:14:30.067641Z".to_owned(),

--- a/test-harness/src/matcher/fused_matcher.rs
+++ b/test-harness/src/matcher/fused_matcher.rs
@@ -1,0 +1,82 @@
+use std::fmt::Display;
+
+use crate::Matcher;
+
+/// Wraps another [`Matcher`] and stops calling [`Matcher::matches`] on it after it first returns
+/// `true`.
+pub struct FusedMatcher<M> {
+    inner: M,
+    matched: bool,
+}
+
+impl<M> FusedMatcher<M> {
+    pub fn new(inner: M) -> Self {
+        Self {
+            inner,
+            matched: false,
+        }
+    }
+}
+
+impl<M: Display> Display for FusedMatcher<M> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+impl<M: Matcher> Matcher for FusedMatcher<M> {
+    fn matches(&mut self, event: &crate::Event) -> miette::Result<bool> {
+        if self.matched {
+            Ok(true)
+        } else {
+            let res = self.inner.matches(event)?;
+            self.matched = res;
+            Ok(res)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tracing::Level;
+
+    use crate::tracing_json::Span;
+    use crate::Event;
+    use crate::IntoMatcher;
+
+    use super::*;
+
+    #[test]
+    fn test_fused_matcher() {
+        let mut matcher = "puppy".into_matcher().unwrap().fused();
+        let event = Event {
+            message: "puppy".to_owned(),
+            timestamp: "2023-08-25T22:14:30.067641Z".to_owned(),
+            level: Level::INFO,
+            fields: Default::default(),
+            target: "ghciwatch::ghci".to_owned(),
+            span: Some(Span {
+                name: "ghci".to_owned(),
+                rest: Default::default(),
+            }),
+            spans: vec![Span {
+                name: "ghci".to_owned(),
+                rest: Default::default(),
+            }],
+        };
+
+        assert!(!matcher
+            .matches(&Event {
+                message: "doggy".to_owned(),
+                ..event.clone()
+            })
+            .unwrap());
+        assert!(matcher.matches(&event).unwrap());
+        assert!(matcher
+            .matches(&Event {
+                message: "doggy".to_owned(),
+                ..event
+            })
+            .unwrap());
+    }
+}

--- a/test-harness/src/matcher/into_matcher.rs
+++ b/test-harness/src/matcher/into_matcher.rs
@@ -1,3 +1,5 @@
+use miette::Diagnostic;
+
 use crate::BaseMatcher;
 use crate::Matcher;
 
@@ -34,5 +36,17 @@ impl IntoMatcher for &str {
 
     fn into_matcher(self) -> miette::Result<Self::Matcher> {
         Ok(BaseMatcher::message(self))
+    }
+}
+
+impl<M, E> IntoMatcher for Result<M, E>
+where
+    M: IntoMatcher,
+    E: Diagnostic + Send + Sync + 'static,
+{
+    type Matcher = <M as IntoMatcher>::Matcher;
+
+    fn into_matcher(self) -> miette::Result<Self::Matcher> {
+        self.map_err(|err| miette::Report::new(err))?.into_matcher()
     }
 }

--- a/test-harness/src/matcher/into_matcher.rs
+++ b/test-harness/src/matcher/into_matcher.rs
@@ -1,0 +1,38 @@
+use crate::BaseMatcher;
+use crate::Matcher;
+
+/// A type that can be converted into a [`Matcher`] and used for searching log events.
+pub trait IntoMatcher {
+    /// The resulting [`Matcher`] type.
+    type Matcher: Matcher;
+
+    /// Convert the object into a `Matcher`.
+    fn into_matcher(self) -> miette::Result<Self::Matcher>;
+}
+
+impl<M> IntoMatcher for M
+where
+    M: Matcher,
+{
+    type Matcher = Self;
+
+    fn into_matcher(self) -> miette::Result<Self::Matcher> {
+        Ok(self)
+    }
+}
+
+impl IntoMatcher for &BaseMatcher {
+    type Matcher = BaseMatcher;
+
+    fn into_matcher(self) -> miette::Result<Self::Matcher> {
+        Ok(self.clone())
+    }
+}
+
+impl IntoMatcher for &str {
+    type Matcher = BaseMatcher;
+
+    fn into_matcher(self) -> miette::Result<Self::Matcher> {
+        Ok(BaseMatcher::message(self))
+    }
+}

--- a/test-harness/src/matcher/mod.rs
+++ b/test-harness/src/matcher/mod.rs
@@ -1,0 +1,73 @@
+use std::fmt::Display;
+
+use crate::Event;
+
+mod into_matcher;
+pub use into_matcher::IntoMatcher;
+
+mod base_matcher;
+pub use base_matcher::BaseMatcher;
+
+mod or_matcher;
+pub use or_matcher::OrMatcher;
+
+mod and_matcher;
+pub use and_matcher::AndMatcher;
+
+mod fused_matcher;
+pub use fused_matcher::FusedMatcher;
+
+mod option_matcher;
+pub use option_matcher::OptionMatcher;
+
+mod never_matcher;
+pub use never_matcher::NeverMatcher;
+
+/// A type which can match log events.
+pub trait Matcher: Display {
+    /// Feeds an event to the matcher and determines if the matcher has finished.
+    ///
+    /// Note that matchers may need multiple separate log messages to complete matching.
+    fn matches(&mut self, event: &Event) -> miette::Result<bool>;
+
+    /// Construct a matcher that matches when this matcher or the `other` matcher have
+    /// finished matching.
+    fn or<O>(self, other: O) -> miette::Result<OrMatcher<Self, <O as IntoMatcher>::Matcher>>
+    where
+        O: IntoMatcher,
+        Self: Sized,
+    {
+        Ok(OrMatcher(self, other.into_matcher()?))
+    }
+
+    /// Construct a matcher that matches when this matcher and the `other` matcher have
+    /// finished matching.
+    fn and<O>(
+        self,
+        other: O,
+    ) -> miette::Result<AndMatcher<FusedMatcher<Self>, FusedMatcher<<O as IntoMatcher>::Matcher>>>
+    where
+        O: IntoMatcher,
+        Self: Sized,
+    {
+        Ok(AndMatcher(self.fused(), other.into_matcher()?.fused()))
+    }
+
+    /// Construct a matcher that stops calling [`Matcher::matches`] on this matcher after it
+    /// first returns `true`.
+    fn fused(self) -> FusedMatcher<Self>
+    where
+        Self: Sized,
+    {
+        FusedMatcher::new(self)
+    }
+}
+
+impl<M> Matcher for &mut M
+where
+    M: Matcher,
+{
+    fn matches(&mut self, event: &Event) -> miette::Result<bool> {
+        (*self).matches(event)
+    }
+}

--- a/test-harness/src/matcher/negative_matcher.rs
+++ b/test-harness/src/matcher/negative_matcher.rs
@@ -1,32 +1,47 @@
 use std::fmt::Display;
 
+use miette::miette;
+
 use crate::Event;
 use crate::Matcher;
 
-/// A [`Matcher`] that can match either of two other matchers.
-pub struct OrMatcher<A, B>(pub A, pub B);
+/// Wraps two matchers. The first matcher is used as normal, except if the negative matcher
+/// matches an event, [`Matcher::matches`] errors.
+pub struct NegativeMatcher<M, N> {
+    inner: M,
+    negative: N,
+}
 
-impl<A, B> Display for OrMatcher<A, B>
+impl<M, N> NegativeMatcher<M, N> {
+    /// Construct a matcher that matches if `inner` matches and errors if `negative` matches.
+    pub fn new(inner: M, negative: N) -> Self {
+        Self { inner, negative }
+    }
+}
+
+impl<A, B> Display for NegativeMatcher<A, B>
 where
     A: Display,
     B: Display,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} or {}", self.0, self.1)
+        write!(f, "{} but not {}", self.inner, self.negative)
     }
 }
 
-impl<A, B> Matcher for OrMatcher<A, B>
+impl<A, B> Matcher for NegativeMatcher<A, B>
 where
     A: Display + Matcher,
     B: Display + Matcher,
 {
     fn matches(&mut self, event: &Event) -> miette::Result<bool> {
-        // There may be some overlap in the events these matchers require to complete, so we
-        // eagerly evaluate both matchers before combining the boolean result.
-        let match_a = self.0.matches(event)?;
-        let match_b = self.1.matches(event)?;
-        Ok(match_a || match_b)
+        if self.negative.matches(event)? {
+            Err(miette!("Log event matched {}: {}", self.negative, event))
+        } else if self.inner.matches(event)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }
 
@@ -40,11 +55,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_or_matcher() {
-        let mut matcher = "puppy"
-            .into_matcher()
-            .unwrap()
-            .or("doggy".into_matcher().unwrap());
+    fn test_negative_matcher() {
         let event = Event {
             message: "puppy".to_owned(),
             timestamp: "2023-08-25T22:14:30.067641Z".to_owned(),
@@ -61,12 +72,17 @@ mod tests {
             }],
         };
 
+        let mut matcher = "puppy"
+            .into_matcher()
+            .unwrap()
+            .but_not("doggy".into_matcher().unwrap());
+
         assert!(matcher.matches(&event).unwrap());
         assert!(matcher
             .matches(&Event {
                 message: "doggy".to_owned(),
                 ..event
             })
-            .unwrap());
+            .is_err());
     }
 }

--- a/test-harness/src/matcher/never_matcher.rs
+++ b/test-harness/src/matcher/never_matcher.rs
@@ -1,0 +1,18 @@
+use std::fmt::Display;
+
+use crate::Matcher;
+
+/// A matcher that never matches.
+pub struct NeverMatcher;
+
+impl Display for NeverMatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[nothing]")
+    }
+}
+
+impl Matcher for NeverMatcher {
+    fn matches(&mut self, _event: &crate::Event) -> miette::Result<bool> {
+        Ok(false)
+    }
+}

--- a/test-harness/src/matcher/option_matcher.rs
+++ b/test-harness/src/matcher/option_matcher.rs
@@ -1,0 +1,118 @@
+use std::fmt::Display;
+
+use crate::IntoMatcher;
+use crate::Matcher;
+
+use super::NeverMatcher;
+
+/// A matcher which may or may not contain a matcher.
+///
+/// If it does not contain a matcher, it never matches.
+pub struct OptionMatcher<M>(Option<M>);
+
+impl OptionMatcher<NeverMatcher> {
+    /// Construct an empty matcher.
+    pub fn none() -> Self {
+        Self(None)
+    }
+}
+
+impl<M: Matcher> OptionMatcher<M> {
+    /// Construct a matcher from the given inner matcher.
+    pub fn some(inner: M) -> Self {
+        Self(Some(inner))
+    }
+}
+
+impl<M: Display> Display for OptionMatcher<M> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.0 {
+            Some(matcher) => write!(f, "{matcher}"),
+            None => write!(f, "(nothing)"),
+        }
+    }
+}
+
+impl<M: Matcher> Matcher for OptionMatcher<M> {
+    fn matches(&mut self, event: &crate::Event) -> miette::Result<bool> {
+        match &mut self.0 {
+            Some(ref mut matcher) => matcher.matches(event),
+            None => Ok(false),
+        }
+    }
+}
+
+impl<M: Matcher> IntoMatcher for Option<M> {
+    type Matcher = OptionMatcher<M>;
+
+    fn into_matcher(self) -> miette::Result<Self::Matcher> {
+        Ok(OptionMatcher(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tracing::Level;
+
+    use crate::tracing_json::Span;
+    use crate::Event;
+    use crate::IntoMatcher;
+
+    use super::*;
+
+    #[test]
+    fn test_option_matcher_some() {
+        let mut matcher = OptionMatcher::some("puppy".into_matcher().unwrap());
+        let event = Event {
+            message: "puppy".to_owned(),
+            timestamp: "2023-08-25T22:14:30.067641Z".to_owned(),
+            level: Level::INFO,
+            fields: Default::default(),
+            target: "ghciwatch::ghci".to_owned(),
+            span: Some(Span {
+                name: "ghci".to_owned(),
+                rest: Default::default(),
+            }),
+            spans: vec![Span {
+                name: "ghci".to_owned(),
+                rest: Default::default(),
+            }],
+        };
+
+        assert!(matcher.matches(&event).unwrap());
+        assert!(!matcher
+            .matches(&Event {
+                message: "doggy".to_owned(),
+                ..event
+            })
+            .unwrap());
+    }
+
+    #[test]
+    fn test_option_matcher_none() {
+        let mut matcher = OptionMatcher::none();
+        let event = Event {
+            message: "puppy".to_owned(),
+            timestamp: "2023-08-25T22:14:30.067641Z".to_owned(),
+            level: Level::INFO,
+            fields: Default::default(),
+            target: "ghciwatch::ghci".to_owned(),
+            span: Some(Span {
+                name: "ghci".to_owned(),
+                rest: Default::default(),
+            }),
+            spans: vec![Span {
+                name: "ghci".to_owned(),
+                rest: Default::default(),
+            }],
+        };
+
+        assert!(!matcher.matches(&event).unwrap());
+        assert!(!matcher
+            .matches(&Event {
+                message: "doggy".to_owned(),
+                ..event
+            })
+            .unwrap());
+    }
+}

--- a/test-harness/src/matcher/or_matcher.rs
+++ b/test-harness/src/matcher/or_matcher.rs
@@ -1,0 +1,69 @@
+use std::fmt::Display;
+
+use crate::Event;
+use crate::Matcher;
+
+/// A [`Matcher`] that can match either of two other matchers.
+pub struct OrMatcher<A, B>(pub A, pub B);
+
+impl<A, B> Display for OrMatcher<A, B>
+where
+    A: Display,
+    B: Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} or {}", self.0, self.1)
+    }
+}
+
+impl<A, B> Matcher for OrMatcher<A, B>
+where
+    A: Display + Matcher,
+    B: Display + Matcher,
+{
+    fn matches(&mut self, event: &Event) -> miette::Result<bool> {
+        // There may be some overlap in the events these matchers require to complete, so we
+        // eagerly evaluate both matchers before combining the boolean result.
+        let match_a = self.0.matches(event)?;
+        let match_b = self.1.matches(event)?;
+        Ok(match_a || match_b)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tracing::Level;
+
+    use crate::tracing_json::Span;
+    use crate::IntoMatcher;
+
+    use super::*;
+
+    #[test]
+    fn test_or_matcher() {
+        let mut matcher = "puppy".into_matcher().unwrap().or("doggy").unwrap();
+        let event = Event {
+            message: "puppy".to_owned(),
+            timestamp: "2023-08-25T22:14:30.067641Z".to_owned(),
+            level: Level::INFO,
+            fields: Default::default(),
+            target: "ghciwatch::ghci".to_owned(),
+            span: Some(Span {
+                name: "ghci".to_owned(),
+                rest: Default::default(),
+            }),
+            spans: vec![Span {
+                name: "ghci".to_owned(),
+                rest: Default::default(),
+            }],
+        };
+
+        assert!(matcher.matches(&event).unwrap());
+        assert!(matcher
+            .matches(&Event {
+                message: "doggy".to_owned(),
+                ..event
+            })
+            .unwrap());
+    }
+}

--- a/tests/error_log.rs
+++ b/tests/error_log.rs
@@ -66,7 +66,7 @@ async fn can_write_error_log_compilation_errors() {
         .expect("ghciwatch loads new modules");
 
     session
-        .assert_logged(BaseMatcher::span_close().in_span("error_log_write"))
+        .wait_for_log(BaseMatcher::span_close().in_span("error_log_write"))
         .await
         .expect("ghciwatch writes ghcid.txt");
 
@@ -111,7 +111,7 @@ async fn can_write_error_log_compilation_errors() {
         .expect("ghciwatch reloads on changes");
 
     session
-        .assert_logged(BaseMatcher::span_close().in_span("error_log_write"))
+        .wait_for_log(BaseMatcher::span_close().in_span("error_log_write"))
         .await
         .expect("ghciwatch writes ghcid.txt");
 

--- a/tests/error_log.rs
+++ b/tests/error_log.rs
@@ -3,9 +3,9 @@ use indoc::indoc;
 
 use test_harness::fs;
 use test_harness::test;
+use test_harness::BaseMatcher;
 use test_harness::GhcVersion::*;
 use test_harness::GhciWatchBuilder;
-use test_harness::Matcher;
 
 /// Test that `ghciwatch --errors ...` can write the error log.
 #[test]
@@ -66,7 +66,7 @@ async fn can_write_error_log_compilation_errors() {
         .expect("ghciwatch loads new modules");
 
     session
-        .assert_logged(Matcher::span_close().in_span("error_log_write"))
+        .assert_logged(BaseMatcher::span_close().in_span("error_log_write"))
         .await
         .expect("ghciwatch writes ghcid.txt");
 
@@ -111,7 +111,7 @@ async fn can_write_error_log_compilation_errors() {
         .expect("ghciwatch reloads on changes");
 
     session
-        .assert_logged(Matcher::span_close().in_span("error_log_write"))
+        .assert_logged(BaseMatcher::span_close().in_span("error_log_write"))
         .await
         .expect("ghciwatch writes ghcid.txt");
 

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -2,6 +2,7 @@ use indoc::indoc;
 
 use test_harness::fs;
 use test_harness::test;
+use test_harness::BaseMatcher;
 use test_harness::GhciWatchBuilder;
 use test_harness::Matcher;
 
@@ -25,13 +26,13 @@ async fn can_eval_commands() {
         .await
         .expect("ghciwatch didn't start in time");
 
-    let eval_message = Matcher::message(r"MyModule.hs:\d+:\d+: example \+\+ example");
+    let eval_message = BaseMatcher::message(r"MyModule.hs:\d+:\d+: example \+\+ example");
     session
         .assert_logged(&eval_message)
         .await
         .expect("ghciwatch evals commands");
     session
-        .assert_logged(Matcher::message("Read line").with_field("line", "exampleexample"))
+        .assert_logged(BaseMatcher::message("Read line").with_field("line", "exampleexample"))
         .await
         .expect("ghciwatch evals commands");
 
@@ -45,7 +46,7 @@ async fn can_eval_commands() {
     session
         .assert_not_logged(
             &eval_message,
-            Matcher::span_close()
+            BaseMatcher::span_close()
                 .in_span("reload")
                 .in_module("ghciwatch::ghci"),
         )
@@ -79,14 +80,15 @@ async fn can_load_new_eval_commands_multiline() {
         .await
         .unwrap();
 
-    let eval_message = Matcher::message(&format!(r"MyModule.hs:\d+:\d+: {}", regex::escape(cmd)));
+    let eval_message =
+        BaseMatcher::message(&format!(r"MyModule.hs:\d+:\d+: {}", regex::escape(cmd)));
     session
         .assert_logged(&eval_message)
         .await
         .expect("ghciwatch evals commands");
     session
         .assert_logged(
-            Matcher::message("Read line").with_field("line", r#"^"exampleexampleexample"$"#),
+            BaseMatcher::message("Read line").with_field("line", r#"^"exampleexampleexample"$"#),
         )
         .await
         .expect("ghciwatch evals commands");
@@ -101,7 +103,7 @@ async fn can_load_new_eval_commands_multiline() {
     session
         .assert_not_logged(
             &eval_message,
-            Matcher::span_close()
+            BaseMatcher::span_close()
                 .in_span("reload")
                 .in_module("ghciwatch::ghci"),
         )

--- a/tests/failed_modules.rs
+++ b/tests/failed_modules.rs
@@ -18,7 +18,7 @@ async fn can_start_with_failed_modules() {
     let module_path = session.path(module_path);
 
     session
-        .assert_logged("Compilation failed")
+        .wait_for_log("Compilation failed")
         .await
         .expect("ghciwatch fails to load with errors");
 
@@ -29,7 +29,7 @@ async fn can_start_with_failed_modules() {
         .unwrap();
 
     session
-        .assert_logged("Compilation succeeded")
+        .wait_for_log("Compilation succeeded")
         .await
         .expect("ghciwatch reloads fixed modules");
 }

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -1,7 +1,7 @@
 use test_harness::fs;
 use test_harness::test;
+use test_harness::BaseMatcher;
 use test_harness::GhciWatchBuilder;
-use test_harness::Matcher;
 
 /// Test that `ghciwatch` can run its lifecycle hooks.
 ///
@@ -39,25 +39,25 @@ async fn can_run_hooks() {
 
     session
         .assert_logged(
-            Matcher::message("Running after-startup command")
+            BaseMatcher::message("Running after-startup command")
                 .with_field("command", "putStrLn \"after-startup-1\""),
         )
         .await
         .unwrap();
     session
-        .assert_logged(Matcher::message("Read line").with_field("line", "^after-startup-1$"))
+        .assert_logged(BaseMatcher::message("Read line").with_field("line", "^after-startup-1$"))
         .await
         .unwrap();
 
     session
         .assert_logged(
-            Matcher::message("Running after-startup command")
+            BaseMatcher::message("Running after-startup command")
                 .with_field("command", "putStrLn \"after-startup-2\""),
         )
         .await
         .unwrap();
     session
-        .assert_logged(Matcher::message("Read line").with_field("line", "^after-startup-2$"))
+        .assert_logged(BaseMatcher::message("Read line").with_field("line", "^after-startup-2$"))
         .await
         .unwrap();
 
@@ -68,50 +68,50 @@ async fn can_run_hooks() {
     // Before reload
     session
         .assert_logged(
-            Matcher::message("Running before-reload command")
+            BaseMatcher::message("Running before-reload command")
                 .with_field("command", "putStrLn \"before-reload-1\""),
         )
         .await
         .unwrap();
     session
-        .assert_logged(Matcher::message("Read line").with_field("line", "^before-reload-1$"))
+        .assert_logged(BaseMatcher::message("Read line").with_field("line", "^before-reload-1$"))
         .await
         .unwrap();
 
     session
         .assert_logged(
-            Matcher::message("Running before-reload command")
+            BaseMatcher::message("Running before-reload command")
                 .with_field("command", "putStrLn \"before-reload-2\""),
         )
         .await
         .unwrap();
     session
-        .assert_logged(Matcher::message("Read line").with_field("line", "^before-reload-2$"))
+        .assert_logged(BaseMatcher::message("Read line").with_field("line", "^before-reload-2$"))
         .await
         .unwrap();
 
     // After reload
     session
         .assert_logged(
-            Matcher::message("Running after-reload command")
+            BaseMatcher::message("Running after-reload command")
                 .with_field("command", "putStrLn \"after-reload-1\""),
         )
         .await
         .unwrap();
     session
-        .assert_logged(Matcher::message("Read line").with_field("line", "^after-reload-1$"))
+        .assert_logged(BaseMatcher::message("Read line").with_field("line", "^after-reload-1$"))
         .await
         .unwrap();
 
     session
         .assert_logged(
-            Matcher::message("Running after-reload command")
+            BaseMatcher::message("Running after-reload command")
                 .with_field("command", "putStrLn \"after-reload-2\""),
         )
         .await
         .unwrap();
     session
-        .assert_logged(Matcher::message("Read line").with_field("line", "^after-reload-2$"))
+        .assert_logged(BaseMatcher::message("Read line").with_field("line", "^after-reload-2$"))
         .await
         .unwrap();
 
@@ -119,50 +119,50 @@ async fn can_run_hooks() {
     // Before restart
     session
         .assert_logged(
-            Matcher::message("Running before-restart command")
+            BaseMatcher::message("Running before-restart command")
                 .with_field("command", "putStrLn \"before-restart-1\""),
         )
         .await
         .unwrap();
     session
-        .assert_logged(Matcher::message("Read line").with_field("line", "^before-restart-1$"))
+        .assert_logged(BaseMatcher::message("Read line").with_field("line", "^before-restart-1$"))
         .await
         .unwrap();
 
     session
         .assert_logged(
-            Matcher::message("Running before-restart command")
+            BaseMatcher::message("Running before-restart command")
                 .with_field("command", "putStrLn \"before-restart-2\""),
         )
         .await
         .unwrap();
     session
-        .assert_logged(Matcher::message("Read line").with_field("line", "^before-restart-2$"))
+        .assert_logged(BaseMatcher::message("Read line").with_field("line", "^before-restart-2$"))
         .await
         .unwrap();
 
     // After restart
     session
         .assert_logged(
-            Matcher::message("Running after-restart command")
+            BaseMatcher::message("Running after-restart command")
                 .with_field("command", "putStrLn \"after-restart-1\""),
         )
         .await
         .unwrap();
     session
-        .assert_logged(Matcher::message("Read line").with_field("line", "^after-restart-1$"))
+        .assert_logged(BaseMatcher::message("Read line").with_field("line", "^after-restart-1$"))
         .await
         .unwrap();
 
     session
         .assert_logged(
-            Matcher::message("Running after-restart command")
+            BaseMatcher::message("Running after-restart command")
                 .with_field("command", "putStrLn \"after-restart-2\""),
         )
         .await
         .unwrap();
     session
-        .assert_logged(Matcher::message("Read line").with_field("line", "^after-restart-2$"))
+        .assert_logged(BaseMatcher::message("Read line").with_field("line", "^after-restart-2$"))
         .await
         .unwrap();
 }

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -38,26 +38,26 @@ async fn can_run_hooks() {
         .expect("ghciwatch starts");
 
     session
-        .assert_logged(
+        .wait_for_log(
             BaseMatcher::message("Running after-startup command")
                 .with_field("command", "putStrLn \"after-startup-1\""),
         )
         .await
         .unwrap();
     session
-        .assert_logged(BaseMatcher::message("Read line").with_field("line", "^after-startup-1$"))
+        .wait_for_log(BaseMatcher::message("Read line").with_field("line", "^after-startup-1$"))
         .await
         .unwrap();
 
     session
-        .assert_logged(
+        .wait_for_log(
             BaseMatcher::message("Running after-startup command")
                 .with_field("command", "putStrLn \"after-startup-2\""),
         )
         .await
         .unwrap();
     session
-        .assert_logged(BaseMatcher::message("Read line").with_field("line", "^after-startup-2$"))
+        .wait_for_log(BaseMatcher::message("Read line").with_field("line", "^after-startup-2$"))
         .await
         .unwrap();
 
@@ -67,102 +67,102 @@ async fn can_run_hooks() {
 
     // Before reload
     session
-        .assert_logged(
+        .wait_for_log(
             BaseMatcher::message("Running before-reload command")
                 .with_field("command", "putStrLn \"before-reload-1\""),
         )
         .await
         .unwrap();
     session
-        .assert_logged(BaseMatcher::message("Read line").with_field("line", "^before-reload-1$"))
+        .wait_for_log(BaseMatcher::message("Read line").with_field("line", "^before-reload-1$"))
         .await
         .unwrap();
 
     session
-        .assert_logged(
+        .wait_for_log(
             BaseMatcher::message("Running before-reload command")
                 .with_field("command", "putStrLn \"before-reload-2\""),
         )
         .await
         .unwrap();
     session
-        .assert_logged(BaseMatcher::message("Read line").with_field("line", "^before-reload-2$"))
+        .wait_for_log(BaseMatcher::message("Read line").with_field("line", "^before-reload-2$"))
         .await
         .unwrap();
 
     // After reload
     session
-        .assert_logged(
+        .wait_for_log(
             BaseMatcher::message("Running after-reload command")
                 .with_field("command", "putStrLn \"after-reload-1\""),
         )
         .await
         .unwrap();
     session
-        .assert_logged(BaseMatcher::message("Read line").with_field("line", "^after-reload-1$"))
+        .wait_for_log(BaseMatcher::message("Read line").with_field("line", "^after-reload-1$"))
         .await
         .unwrap();
 
     session
-        .assert_logged(
+        .wait_for_log(
             BaseMatcher::message("Running after-reload command")
                 .with_field("command", "putStrLn \"after-reload-2\""),
         )
         .await
         .unwrap();
     session
-        .assert_logged(BaseMatcher::message("Read line").with_field("line", "^after-reload-2$"))
+        .wait_for_log(BaseMatcher::message("Read line").with_field("line", "^after-reload-2$"))
         .await
         .unwrap();
 
     fs::remove(session.path("src/MyModule.hs")).await.unwrap();
     // Before restart
     session
-        .assert_logged(
+        .wait_for_log(
             BaseMatcher::message("Running before-restart command")
                 .with_field("command", "putStrLn \"before-restart-1\""),
         )
         .await
         .unwrap();
     session
-        .assert_logged(BaseMatcher::message("Read line").with_field("line", "^before-restart-1$"))
+        .wait_for_log(BaseMatcher::message("Read line").with_field("line", "^before-restart-1$"))
         .await
         .unwrap();
 
     session
-        .assert_logged(
+        .wait_for_log(
             BaseMatcher::message("Running before-restart command")
                 .with_field("command", "putStrLn \"before-restart-2\""),
         )
         .await
         .unwrap();
     session
-        .assert_logged(BaseMatcher::message("Read line").with_field("line", "^before-restart-2$"))
+        .wait_for_log(BaseMatcher::message("Read line").with_field("line", "^before-restart-2$"))
         .await
         .unwrap();
 
     // After restart
     session
-        .assert_logged(
+        .wait_for_log(
             BaseMatcher::message("Running after-restart command")
                 .with_field("command", "putStrLn \"after-restart-1\""),
         )
         .await
         .unwrap();
     session
-        .assert_logged(BaseMatcher::message("Read line").with_field("line", "^after-restart-1$"))
+        .wait_for_log(BaseMatcher::message("Read line").with_field("line", "^after-restart-1$"))
         .await
         .unwrap();
 
     session
-        .assert_logged(
+        .wait_for_log(
             BaseMatcher::message("Running after-restart command")
                 .with_field("command", "putStrLn \"after-restart-2\""),
         )
         .await
         .unwrap();
     session
-        .assert_logged(BaseMatcher::message("Read line").with_field("line", "^after-restart-2$"))
+        .wait_for_log(BaseMatcher::message("Read line").with_field("line", "^after-restart-2$"))
         .await
         .unwrap();
 }

--- a/tests/reload.rs
+++ b/tests/reload.rs
@@ -32,7 +32,7 @@ async fn can_reload() {
         .await
         .expect("ghciwatch reloads on changes");
     session
-        .assert_logged(
+        .wait_for_log(
             BaseMatcher::span_close()
                 .in_module("ghciwatch::ghci")
                 .in_spans(["on_action", "reload"]),
@@ -69,9 +69,7 @@ async fn can_reload_after_error() {
         .await
         .expect("ghciwatch loads new modules");
     session
-        .assert_logged(
-            BaseMatcher::message("Compilation failed").in_spans(["reload", "add_module"]),
-        )
+        .wait_for_log(BaseMatcher::message("Compilation failed").in_spans(["reload", "add_module"]))
         .await
         .unwrap();
 
@@ -84,7 +82,7 @@ async fn can_reload_after_error() {
         .await
         .expect("ghciwatch reloads on changes");
     session
-        .assert_logged(BaseMatcher::message("Compilation succeeded").in_span("reload"))
+        .wait_for_log(BaseMatcher::message("Compilation succeeded").in_span("reload"))
         .await
         .unwrap();
 }

--- a/tests/reload.rs
+++ b/tests/reload.rs
@@ -2,8 +2,8 @@ use indoc::indoc;
 
 use test_harness::fs;
 use test_harness::test;
+use test_harness::BaseMatcher;
 use test_harness::GhciWatch;
-use test_harness::Matcher;
 
 /// Test that `ghciwatch` can start up and then reload on changes.
 #[test]
@@ -33,7 +33,7 @@ async fn can_reload() {
         .expect("ghciwatch reloads on changes");
     session
         .assert_logged(
-            Matcher::span_close()
+            BaseMatcher::span_close()
                 .in_module("ghciwatch::ghci")
                 .in_spans(["on_action", "reload"]),
         )
@@ -69,7 +69,9 @@ async fn can_reload_after_error() {
         .await
         .expect("ghciwatch loads new modules");
     session
-        .assert_logged(Matcher::message("Compilation failed").in_spans(["reload", "add_module"]))
+        .assert_logged(
+            BaseMatcher::message("Compilation failed").in_spans(["reload", "add_module"]),
+        )
         .await
         .unwrap();
 
@@ -82,7 +84,7 @@ async fn can_reload_after_error() {
         .await
         .expect("ghciwatch reloads on changes");
     session
-        .assert_logged(Matcher::message("Compilation succeeded").in_span("reload"))
+        .assert_logged(BaseMatcher::message("Compilation succeeded").in_span("reload"))
         .await
         .unwrap();
 }

--- a/tests/rename.rs
+++ b/tests/rename.rs
@@ -1,7 +1,7 @@
 use test_harness::fs;
 use test_harness::test;
+use test_harness::BaseMatcher;
 use test_harness::GhciWatch;
-use test_harness::Matcher;
 
 /// Test that `ghciwatch` can restart correctly when modules are removed and added (i.e., renamed)
 /// at the same time.
@@ -25,7 +25,7 @@ async fn can_compile_renamed_module() {
         .expect("ghciwatch restarts on module move");
 
     session
-        .assert_logged(Matcher::message("Compilation failed").in_span("reload"))
+        .wait_for_log(BaseMatcher::compilation_failed())
         .await
         .unwrap();
 
@@ -39,7 +39,7 @@ async fn can_compile_renamed_module() {
         .expect("ghciwatch reloads on module change");
 
     session
-        .assert_logged(Matcher::message("Compilation succeeded").in_span("reload"))
+        .wait_for_log(BaseMatcher::compilation_succeeded())
         .await
         .unwrap();
 }

--- a/tests/restart.rs
+++ b/tests/restart.rs
@@ -4,6 +4,7 @@ use test_harness::fs;
 use test_harness::test;
 use test_harness::BaseMatcher;
 use test_harness::GhciWatch;
+use test_harness::GhciWatchBuilder;
 
 /// Test that `ghciwatch` can restart `ghci` after a module is moved.
 #[test]

--- a/tests/restart.rs
+++ b/tests/restart.rs
@@ -2,9 +2,8 @@ use indoc::indoc;
 
 use test_harness::fs;
 use test_harness::test;
+use test_harness::BaseMatcher;
 use test_harness::GhciWatch;
-use test_harness::GhciWatchBuilder;
-use test_harness::Matcher;
 
 /// Test that `ghciwatch` can restart `ghci` after a module is moved.
 #[test]
@@ -53,7 +52,7 @@ async fn can_restart_after_module_move() {
 
     session
         .assert_logged(
-            Matcher::message("Compiling")
+            BaseMatcher::message("Compiling")
                 .in_span("reload")
                 .with_field("module", r"My\.CoolModule"),
         )
@@ -61,7 +60,7 @@ async fn can_restart_after_module_move() {
         .unwrap();
 
     session
-        .assert_logged(Matcher::message("Compilation succeeded").in_span("reload"))
+        .assert_logged(BaseMatcher::message("Compilation succeeded").in_span("reload"))
         .await
         .unwrap();
 }

--- a/tests/restart.rs
+++ b/tests/restart.rs
@@ -51,7 +51,7 @@ async fn can_restart_after_module_move() {
         .expect("ghciwatch restarts ghci");
 
     session
-        .assert_logged(
+        .wait_for_log(
             BaseMatcher::message("Compiling")
                 .in_span("reload")
                 .with_field("module", r"My\.CoolModule"),
@@ -60,7 +60,7 @@ async fn can_restart_after_module_move() {
         .unwrap();
 
     session
-        .assert_logged(BaseMatcher::message("Compilation succeeded").in_span("reload"))
+        .wait_for_log(BaseMatcher::message("Compilation succeeded").in_span("reload"))
         .await
         .unwrap();
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,8 +1,8 @@
 use expect_test::expect;
 use test_harness::fs;
 use test_harness::test;
+use test_harness::BaseMatcher;
 use test_harness::GhciWatchBuilder;
-use test_harness::Matcher;
 
 /// Test that `ghciwatch --test ...` can run a test suite.
 #[test]
@@ -24,7 +24,7 @@ async fn can_run_test_suite_on_reload() {
         .expect("Can touch file");
 
     session
-        .assert_logged(Matcher::span_close().in_span("error_log_write"))
+        .assert_logged(BaseMatcher::span_close().in_span("error_log_write"))
         .await
         .expect("ghciwatch writes ghcid.txt");
     session

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -24,11 +24,11 @@ async fn can_run_test_suite_on_reload() {
         .expect("Can touch file");
 
     session
-        .assert_logged(BaseMatcher::span_close().in_span("error_log_write"))
+        .wait_for_log(BaseMatcher::span_close().in_span("error_log_write"))
         .await
         .expect("ghciwatch writes ghcid.txt");
     session
-        .assert_logged("Finished running tests")
+        .wait_for_log("Finished running tests")
         .await
         .expect("ghciwatch runs the test suite");
 


### PR DESCRIPTION
These matcher combinators will let us express more complex logging concepts, like:
- Match these two events in any order.
- Match either of these two events.
- Match either of these two events, as long as this other event doesn't match first.

There's also a system of checkpoints where log events are read into the default checkpoint. At any time, you can create another checkpoint with `GhciWatch::checkpoint`. Then, log events will be read into the new checkpoint. Later, you can assert that messages were logged in a particular checkpoint or range of checkpoints.