### PR TITLE
Support `async:` commands

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,6 +13,7 @@ use crate::clap::RustBacktrace;
 use crate::clonable_command::ClonableCommand;
 use crate::ghci::GhciCommand;
 use crate::ignore::GlobMatcher;
+use crate::maybe_async_command::MaybeAsyncCommand;
 use crate::normal_path::NormalPath;
 
 /// A `ghci`-based file watcher and Haskell recompiler.
@@ -178,7 +179,7 @@ pub struct HookOpts {
     /// This can be used to regenerate `.cabal` files with `hpack`.
     /// Can be given multiple times.
     #[arg(long, value_name = "SHELL_COMMAND")]
-    pub before_startup_shell: Vec<ClonableCommand>,
+    pub before_startup_shell: Vec<MaybeAsyncCommand>,
 
     /// `ghci` commands to run on startup. Use `:set args ...` in combination with `--test` to set
     /// the command-line arguments for tests.
@@ -199,6 +200,11 @@ pub struct HookOpts {
     #[arg(long, value_name = "GHCI_COMMAND")]
     pub after_reload_ghci: Vec<GhciCommand>,
 
+    /// Shell commands to run after reloading `ghci`.
+    /// Can be given multiple times.
+    #[arg(long, value_name = "SHELL_COMMAND")]
+    pub after_reload_shell: Vec<MaybeAsyncCommand>,
+
     /// `ghci` commands to run before restarting `ghci`.
     ///
     /// See `--after-restart-ghci` for more details.
@@ -217,6 +223,11 @@ pub struct HookOpts {
     /// See: https://gitlab.haskell.org/ghc/ghc/-/issues/9648
     #[arg(long, value_name = "GHCI_COMMAND")]
     pub after_restart_ghci: Vec<GhciCommand>,
+
+    /// Shell commands to run after restarting `ghci`.
+    /// Can be given multiple times.
+    #[arg(long, value_name = "SHELL_COMMAND")]
+    pub after_restart_shell: Vec<MaybeAsyncCommand>,
 }
 
 impl Opts {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ mod ghci;
 mod haskell_source_file;
 mod ignore;
 mod incremental_reader;
+mod maybe_async_command;
 mod normal_path;
 mod shutdown;
 mod tracing;

--- a/src/maybe_async_command.rs
+++ b/src/maybe_async_command.rs
@@ -1,0 +1,148 @@
+use std::fmt::Display;
+use std::process::ExitStatus;
+use std::str::FromStr;
+
+use miette::miette;
+use miette::Context;
+use miette::IntoDiagnostic;
+use tokio::task::JoinHandle;
+use tracing::instrument;
+use winnow::combinator::opt;
+use winnow::combinator::rest;
+use winnow::PResult;
+use winnow::Parser;
+
+use crate::clonable_command::ClonableCommand;
+use crate::command_ext::CommandExt;
+
+/// A shell command which may optionally be run asynchronously.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MaybeAsyncCommand {
+    /// Should this command be run asynchronously?
+    pub is_async: bool,
+    /// The contained command.
+    pub command: ClonableCommand,
+}
+
+impl Display for MaybeAsyncCommand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.command.fmt(f)
+    }
+}
+
+impl FromStr for MaybeAsyncCommand {
+    type Err = miette::Report;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse_maybe_async_command
+            .parse(s)
+            .map_err(|err| miette!("{err}"))
+    }
+}
+
+fn parse_maybe_async_command(input: &mut &str) -> PResult<MaybeAsyncCommand> {
+    let is_async = opt("async:").parse_next(input)?.is_some();
+
+    let command = rest.parse_to().parse_next(input)?;
+
+    Ok(MaybeAsyncCommand { is_async, command })
+}
+
+impl MaybeAsyncCommand {
+    #[instrument(level = "debug")]
+    pub async fn status(&self) -> MaybeAsyncCommandStatus {
+        let program = self.command.program.to_string_lossy().into_owned();
+        let mut command = self.command.as_tokio();
+        let command_formatted = self.display();
+        let join_handle = tokio::task::spawn(async move {
+            tracing::info!("$ {command_formatted}");
+            let status = command
+                .status()
+                .await
+                .into_diagnostic()
+                .wrap_err_with(|| format!("Failed to execute `{command_formatted}`"))?;
+            if status.success() {
+                tracing::debug!("{program:?} exited successfully: {status}");
+            } else {
+                tracing::error!("{program:?} failed: {status}");
+            }
+            Ok(status)
+        });
+
+        if self.is_async {
+            MaybeAsyncCommandStatus::Async(join_handle)
+        } else {
+            let command_formatted = self.display();
+            let status = join_handle
+                .await
+                .into_diagnostic()
+                .wrap_err_with(|| format!("Panicked while executing `{command_formatted}`"))
+                .and_then(std::convert::identity);
+            MaybeAsyncCommandStatus::Sync(status)
+        }
+    }
+
+    /// Run this command.
+    ///
+    /// If it's a synchronous command, report its status. Otherwise, add the [`JoinHandle`] for its
+    /// task to the given list of handles.
+    pub async fn run_on(
+        &self,
+        handles: &mut Vec<JoinHandle<miette::Result<ExitStatus>>>,
+    ) -> miette::Result<()> {
+        match self.status().await {
+            MaybeAsyncCommandStatus::Sync(result) => {
+                // If we failed to execute the program, that's an actual error, but if the
+                // program failed on its own, we'll log and move on.
+                result?;
+            }
+            MaybeAsyncCommandStatus::Async(join_handle) => {
+                // If the program is running asynchronously, we'll store the `JoinHandle`
+                // so we don't kill it and so we can log when it completes.
+                handles.push(join_handle);
+            }
+        }
+        Ok(())
+    }
+}
+
+pub enum MaybeAsyncCommandStatus {
+    Sync(miette::Result<ExitStatus>),
+    Async(JoinHandle<miette::Result<ExitStatus>>),
+}
+
+impl CommandExt for MaybeAsyncCommand {
+    fn display(&self) -> String {
+        self.command.display()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse() {
+        assert_eq!(
+            "puppy --flavor 'sammy' --eyes \"brown\""
+                .parse::<MaybeAsyncCommand>()
+                .unwrap(),
+            MaybeAsyncCommand {
+                is_async: false,
+                command: ClonableCommand::new("puppy")
+                    .args(["--flavor", "sammy", "--eyes", "brown"])
+            }
+        );
+
+        assert_eq!(
+            "async: puppy --flavor 'sammy' --eyes \"brown\""
+                .parse::<MaybeAsyncCommand>()
+                .unwrap(),
+            MaybeAsyncCommand {
+                is_async: true,
+                command: ClonableCommand::new("puppy")
+                    .args(["--flavor", "sammy", "--eyes", "brown"])
+            }
+        );
+    }
+}

--- a/test-harness/src/ghciwatch.rs
+++ b/test-harness/src/ghciwatch.rs
@@ -188,8 +188,7 @@ impl GhciWatch {
             .wrap_err("Failed to start `ghciwatch`")?;
 
         // Wait for `ghciwatch` to create the `log_path`
-        let creates_log_path =
-            tokio::time::timeout(builder.default_timeout, crate::fs::wait_for_path(&log_path));
+        let creates_log_path = crate::fs::wait_for_path(builder.default_timeout, &log_path);
         tokio::select! {
             child_result = child.wait() => {
                 return match child_result {
@@ -202,9 +201,7 @@ impl GhciWatch {
                 }
             }
             log_path_result = creates_log_path => {
-                if log_path_result.is_err() {
-                    return Err(miette!("`ghciwatch` didn't create log path {log_path:?} fast enough"));
-                }
+                log_path_result?;
             }
             else => {}
         }


### PR DESCRIPTION
This lets you prefix shell commands with `async:` to have them run asynchronously. This will let us do things like reindex hie files in the background.