### PR TITLE
Release version 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "ghciwatch"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aho-corasick",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ publish = false # Don't do `cargo publish`.
 # Define the root package: https://doc.rust-lang.org/cargo/reference/workspaces.html#root-package
 [package]
 name = "ghciwatch"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = [
     "Rebecca Turner <rebeccat@mercury.com>"


### PR DESCRIPTION
Update version to 0.4.1 with [cargo-release](https://github.com/crate-ci/cargo-release).
Merge this PR to build and publish a new release.