### PR TITLE
Parse eval commands when they end with EOF instead of a newline

### DIFF
--- a/src/ghci/parse/lines.rs
+++ b/src/ghci/parse/lines.rs
@@ -1,18 +1,25 @@
-use winnow::combinator::terminated;
+use winnow::ascii::line_ending;
+use winnow::ascii::not_line_ending;
+use winnow::combinator::alt;
+use winnow::combinator::eof;
+use winnow::error::ContextError;
+use winnow::error::ErrMode;
 use winnow::stream::AsChar;
+use winnow::stream::Compare;
 use winnow::stream::FindSlice;
+use winnow::stream::SliceLen;
 use winnow::stream::Stream;
 use winnow::stream::StreamIsPartial;
-use winnow::token::take_until0;
 use winnow::PResult;
 use winnow::Parser;
 
 /// Parse the rest of a line, including the newline character.
 pub fn rest_of_line<I>(input: &mut I) -> PResult<<I as Stream>::Slice>
 where
-    I: Stream + StreamIsPartial + for<'i> FindSlice<&'i str>,
+    I: Stream + StreamIsPartial + for<'i> FindSlice<&'i str> + for<'i> Compare<&'i str>,
     <I as Stream>::Token: AsChar,
     <I as Stream>::Token: Clone,
+    <I as Stream>::Slice: SliceLen,
 {
     until_newline.recognize().parse_next(input)
 }
@@ -21,16 +28,25 @@ where
 /// character in the output.
 pub fn until_newline<I>(input: &mut I) -> PResult<<I as Stream>::Slice>
 where
-    I: Stream + StreamIsPartial + for<'i> FindSlice<&'i str>,
+    I: Stream + StreamIsPartial + for<'i> FindSlice<&'i str> + for<'i> Compare<&'i str>,
     <I as Stream>::Token: AsChar,
     <I as Stream>::Token: Clone,
+    <I as Stream>::Slice: SliceLen,
 {
-    terminated(take_until0("\n"), '\n').parse_next(input)
+    let line = not_line_ending.parse_next(input)?;
+    let ending = alt((line_ending, eof)).parse_next(input)?;
+
+    if line.slice_len() == 0 && ending.slice_len() == 0 {
+        Err(ErrMode::Backtrack(ContextError::new()))
+    } else {
+        Ok(line)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;
+    use winnow::combinator::repeat;
 
     use super::*;
 
@@ -41,8 +57,6 @@ mod tests {
         assert_eq!(rest_of_line.parse("foo bar.?\n").unwrap(), "foo bar.?\n");
 
         // Negative cases.
-        // Missing newline:
-        assert!(rest_of_line.parse("foo").is_err());
         // Two newlines:
         assert!(rest_of_line.parse("foo\n\n").is_err());
     }
@@ -54,9 +68,26 @@ mod tests {
         assert_eq!(until_newline.parse("foo bar.?\n").unwrap(), "foo bar.?");
 
         // Negative cases.
-        // Missing newline:
-        assert!(until_newline.parse("foo").is_err());
         // Two newlines:
         assert!(until_newline.parse("foo\n\n").is_err());
+    }
+
+    #[test]
+    fn test_parse_lines_repeat() {
+        fn parser(input: &str) -> miette::Result<Vec<&str>> {
+            repeat(0.., rest_of_line)
+                .parse(input)
+                .map_err(|err| miette::miette!("{err}"))
+        }
+
+        assert_eq!(
+            parser("puppy\ndoggy\n").unwrap(),
+            vec!["puppy\n", "doggy\n"]
+        );
+        assert_eq!(parser("puppy\ndoggy").unwrap(), vec!["puppy\n", "doggy"]);
+        assert_eq!(parser("dog").unwrap(), vec!["dog"]);
+        assert_eq!(parser(" \ndog\n").unwrap(), vec![" \n", "dog\n"]);
+        assert_eq!(parser("\ndog\n").unwrap(), vec!["\n", "dog\n"]);
+        assert_eq!(parser("\n").unwrap(), vec!["\n"]);
     }
 }


### PR DESCRIPTION
With an eval command at the end of the file and no newline at the end of the file, parsing fails.

This happens because [VS Code is a bad text editor](https://stackoverflow.com/questions/44704968/visual-studio-code-insert-newline-at-the-end-of-files) that doesn't respect [POSIX](https://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline), which defines a line as:

> **3.206 Line**
> 
> A sequence of zero or more non- \<newline> characters plus a terminating \<newline> character.

No terminating newline? Not a line.

Anyways, we have to work around this because people aren't exactly going to stop using VS Code.