### PR TITLE
Allow customizing load-bearing sleeps

### DIFF
--- a/test-harness/src/fs.rs
+++ b/test-harness/src/fs.rs
@@ -13,148 +13,204 @@ use tokio::fs::File;
 use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
 
-/// Touch a path.
-#[tracing::instrument]
-pub async fn touch(path: impl AsRef<Path> + Debug) -> miette::Result<()> {
-    let path = path.as_ref();
-    if path.exists() {
-        // I've had trouble with the pure-`open` approach getting detected, so let's actually
-        // write the file's contents again.
-        let contents = read(path).await?;
-        write(path, contents).await
-    } else {
-        if let Some(parent) = path.parent() {
-            create_dir(parent).await?;
+const DEFAULT_SLEEP_DURATION: Duration = Duration::from_secs(1);
+
+fn maybe_sleep_duration() -> Option<Duration> {
+    crate::internal::GHCIWATCH_PROCESS
+        .with(|option| option.borrow().as_ref().map(|_| DEFAULT_SLEEP_DURATION))
+}
+
+/// Filesystem utilities for integration tests.
+#[derive(Debug)]
+pub struct Fs {
+    /// It's generally necessary to sleep before writing files, because the brittle integration
+    /// test environment misses writes when they happen immediately. However, in some cases, it's
+    /// useful to write without delay, so we support disabling the load-bearing sleeps with this
+    /// field.
+    sleep_duration: Option<Duration>,
+}
+
+impl Default for Fs {
+    fn default() -> Self {
+        Self {
+            sleep_duration: maybe_sleep_duration(),
         }
-        OpenOptions::new()
-            .create(true)
-            .write(true)
+    }
+}
+
+impl Fs {
+    /// Create a new filesystem helper.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Disable the load-bearing sleeps, returning the sleep duration (if any).
+    pub fn disable_load_bearing_sleep(&mut self) -> Option<Duration> {
+        self.sleep_duration.take()
+    }
+
+    /// Reset the load-bearing sleeps to the default value.
+    pub fn reset_load_bearing_sleep(&mut self) {
+        self.sleep_duration = maybe_sleep_duration();
+    }
+
+    async fn maybe_sleep(&self) {
+        if let Some(duration) = self.sleep_duration {
+            // Load-bearing sleep! If this is removed, some writes aren't detected some of the time.
+            // Comment it out and run `cargo nextest run` in a loop to see what I mean.
+            tokio::time::sleep(duration).await;
+        }
+    }
+
+    /// Touch a path.
+    #[tracing::instrument]
+    pub async fn touch(&self, path: impl AsRef<Path> + Debug) -> miette::Result<()> {
+        let path = path.as_ref();
+        if path.exists() {
+            // I've had trouble with the pure-`open` approach getting detected, so let's actually
+            // write the file's contents again.
+            let contents = self.read(path).await?;
+            self.write(path, contents).await
+        } else {
+            if let Some(parent) = path.parent() {
+                self.create_dir(parent).await?;
+            }
+            OpenOptions::new()
+                .create(true)
+                .write(true)
+                .open(path)
+                .await
+                .into_diagnostic()
+                .wrap_err_with(|| format!("Failed to touch {path:?}"))
+                .map(|_| ())
+        }
+    }
+
+    /// Write some data to a path, replacing its previous contents.
+    #[tracing::instrument(skip(data))]
+    pub async fn write(
+        &self,
+        path: impl AsRef<Path> + Debug,
+        data: impl AsRef<[u8]>,
+    ) -> miette::Result<()> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            self.create_dir(parent).await?;
+        }
+
+        self.maybe_sleep().await;
+
+        tokio::fs::write(path, data)
+            .await
+            .into_diagnostic()
+            .wrap_err_with(|| format!("Failed to write {path:?}"))
+    }
+
+    /// Append some data to a path.
+    #[tracing::instrument(skip(data))]
+    pub async fn append(
+        &self,
+        path: impl AsRef<Path> + Debug,
+        data: impl AsRef<[u8]>,
+    ) -> miette::Result<()> {
+        let path = path.as_ref();
+        let mut file = OpenOptions::new()
+            .append(true)
             .open(path)
             .await
             .into_diagnostic()
-            .wrap_err_with(|| format!("Failed to touch {path:?}"))
-            .map(|_| ())
-    }
-}
-
-/// Write some data to a path, replacing its previous contents.
-#[tracing::instrument(skip(data))]
-pub async fn write(path: impl AsRef<Path> + Debug, data: impl AsRef<[u8]>) -> miette::Result<()> {
-    let path = path.as_ref();
-    if let Some(parent) = path.parent() {
-        create_dir(parent).await?;
+            .wrap_err_with(|| format!("Failed to open {path:?}"))?;
+        file.write_all(data.as_ref()).await.into_diagnostic()
     }
 
-    if crate::internal::GHCIWATCH_PROCESS.with(|option| option.borrow().is_some()) {
-        // Load-bearing sleep! If this is removed, some writes aren't detected some of the time.
-        // Comment it out and run `cargo nextest run` in a loop to see what I mean.
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    /// Read a path into a string.
+    #[tracing::instrument]
+    pub async fn read(&self, path: impl AsRef<Path> + Debug) -> miette::Result<String> {
+        let path = path.as_ref();
+        tokio::fs::read_to_string(path)
+            .await
+            .into_diagnostic()
+            .wrap_err_with(|| format!("Failed to read {path:?}"))
     }
 
-    tokio::fs::write(path, data)
-        .await
-        .into_diagnostic()
-        .wrap_err_with(|| format!("Failed to write {path:?}"))
-}
-
-/// Append some data to a path.
-#[tracing::instrument(skip(data))]
-pub async fn append(path: impl AsRef<Path> + Debug, data: impl AsRef<[u8]>) -> miette::Result<()> {
-    let path = path.as_ref();
-    let mut file = OpenOptions::new()
-        .append(true)
-        .open(path)
-        .await
-        .into_diagnostic()
-        .wrap_err_with(|| format!("Failed to open {path:?}"))?;
-    file.write_all(data.as_ref()).await.into_diagnostic()
-}
-
-/// Wait for a path to be created.
-///
-/// This should generally be run under a [`tokio::time::timeout`].
-#[tracing::instrument]
-pub async fn wait_for_path(duration: Duration, path: &Path) -> miette::Result<()> {
-    let mut backoff = ExponentialBackoff {
-        max_interval: Duration::from_secs(1),
-        max_elapsed_time: Some(duration),
-        ..Default::default()
-    };
-    while let Some(duration) = backoff.next_backoff() {
-        if (File::open(path).await).is_ok() {
-            return Ok(());
+    /// Read from a path, run a string replacement on its contents, and then write the result.
+    #[tracing::instrument(skip(from, to))]
+    pub async fn replace(
+        &self,
+        path: impl AsRef<Path> + Debug,
+        from: impl AsRef<str>,
+        to: impl AsRef<str>,
+    ) -> miette::Result<()> {
+        let path = path.as_ref();
+        let old_contents = self.read(path).await?;
+        let new_contents = old_contents.replace(from.as_ref(), to.as_ref());
+        if old_contents == new_contents {
+            return Err(miette!(
+                "Replacing substring in file didn't make any changes"
+            ));
         }
-        tracing::debug!("Waiting {duration:?} before retrying");
-        tokio::time::sleep(duration).await;
+        self.write(path, new_contents).await
     }
-    Err(miette!(
-        "Path was not created after waiting {duration:.2?}: {path:?}"
-    ))
-}
 
-/// Read a path into a string.
-#[tracing::instrument]
-pub async fn read(path: impl AsRef<Path> + Debug) -> miette::Result<String> {
-    let path = path.as_ref();
-    tokio::fs::read_to_string(path)
-        .await
-        .into_diagnostic()
-        .wrap_err_with(|| format!("Failed to read {path:?}"))
-}
-
-/// Read from a path, run a string replacement on its contents, and then write the result.
-#[tracing::instrument(skip(from, to))]
-pub async fn replace(
-    path: impl AsRef<Path> + Debug,
-    from: impl AsRef<str>,
-    to: impl AsRef<str>,
-) -> miette::Result<()> {
-    let path = path.as_ref();
-    let old_contents = read(path).await?;
-    let new_contents = old_contents.replace(from.as_ref(), to.as_ref());
-    if old_contents == new_contents {
-        return Err(miette!(
-            "Replacing substring in file didn't make any changes"
-        ));
+    /// Creates a directory and all of its parent components.
+    #[tracing::instrument]
+    pub async fn create_dir(&self, path: impl AsRef<Path> + Debug) -> miette::Result<()> {
+        let path = path.as_ref();
+        tokio::fs::create_dir_all(path)
+            .await
+            .into_diagnostic()
+            .wrap_err_with(|| format!("Failed to create directory {path:?}"))
     }
-    write(path, new_contents).await
-}
 
-/// Creates a directory and all of its parent components.
-#[tracing::instrument]
-pub async fn create_dir(path: impl AsRef<Path> + Debug) -> miette::Result<()> {
-    let path = path.as_ref();
-    tokio::fs::create_dir_all(path)
-        .await
+    /// Remove the file or directory at the given path.
+    ///
+    /// Directories are removed recursively; be careful.
+    #[tracing::instrument]
+    pub async fn remove(&self, path: impl AsRef<Path> + Debug) -> miette::Result<()> {
+        let path = path.as_ref();
+        if path.is_dir() {
+            tokio::fs::remove_dir_all(path).await
+        } else {
+            tokio::fs::remove_file(path).await
+        }
         .into_diagnostic()
-        .wrap_err_with(|| format!("Failed to create directory {path:?}"))
-}
-
-/// Remove the file or directory at the given path.
-///
-/// Directories are removed recursively; be careful.
-#[tracing::instrument]
-pub async fn remove(path: impl AsRef<Path> + Debug) -> miette::Result<()> {
-    let path = path.as_ref();
-    if path.is_dir() {
-        tokio::fs::remove_dir_all(path).await
-    } else {
-        tokio::fs::remove_file(path).await
+        .wrap_err_with(|| format!("Failed to remove {path:?}"))
     }
-    .into_diagnostic()
-    .wrap_err_with(|| format!("Failed to remove {path:?}"))
-}
 
-/// Move the path at `from` to the path at `to`.
-#[tracing::instrument]
-pub async fn rename(
-    from: impl AsRef<Path> + Debug,
-    to: impl AsRef<Path> + Debug,
-) -> miette::Result<()> {
-    let from = from.as_ref();
-    let to = to.as_ref();
-    tokio::fs::rename(from, to)
-        .await
-        .into_diagnostic()
-        .wrap_err_with(|| format!("Failed to move {from:?} to {to:?}"))
+    /// Move the path at `from` to the path at `to`.
+    #[tracing::instrument]
+    pub async fn rename(
+        &self,
+        from: impl AsRef<Path> + Debug,
+        to: impl AsRef<Path> + Debug,
+    ) -> miette::Result<()> {
+        let from = from.as_ref();
+        let to = to.as_ref();
+        tokio::fs::rename(from, to)
+            .await
+            .into_diagnostic()
+            .wrap_err_with(|| format!("Failed to move {from:?} to {to:?}"))
+    }
+
+    /// Wait for a path to be created.
+    ///
+    /// This should generally be run under a [`tokio::time::timeout`].
+    #[tracing::instrument]
+    pub async fn wait_for_path(&self, duration: Duration, path: &Path) -> miette::Result<()> {
+        let mut backoff = ExponentialBackoff {
+            max_interval: Duration::from_secs(1),
+            max_elapsed_time: Some(duration),
+            ..Default::default()
+        };
+        while let Some(duration) = backoff.next_backoff() {
+            if (File::open(path).await).is_ok() {
+                return Ok(());
+            }
+            tracing::debug!("Waiting {duration:?} before retrying");
+            tokio::time::sleep(duration).await;
+        }
+        Err(miette!(
+            "Path was not created after waiting {duration:.2?}: {path:?}"
+        ))
+    }
 }

--- a/test-harness/src/lib.rs
+++ b/test-harness/src/lib.rs
@@ -15,7 +15,8 @@ pub use matcher::IntoMatcher;
 pub use matcher::Matcher;
 pub use matcher::OrMatcher;
 
-pub mod fs;
+mod fs;
+pub use fs::Fs;
 
 pub mod internal;
 

--- a/tests/dot_ghci.rs
+++ b/tests/dot_ghci.rs
@@ -1,5 +1,5 @@
-use test_harness::fs;
 use test_harness::test;
+use test_harness::Fs;
 use test_harness::GhciWatchBuilder;
 
 use indoc::indoc;
@@ -9,16 +9,17 @@ use indoc::indoc;
 async fn can_run_with_custom_ghci_prompt() {
     let mut session = GhciWatchBuilder::new("tests/data/simple")
         .before_start(|project| async move {
-            fs::write(
-                project.join(".ghci"),
-                indoc!(
-                    r#"
+            Fs::new()
+                .write(
+                    project.join(".ghci"),
+                    indoc!(
+                        r#"
                     :set prompt "λ "
                     :set prompt-cont "│ "
                     "#
-                ),
-            )
-            .await?;
+                    ),
+                )
+                .await?;
             Ok(())
         })
         .start()

--- a/tests/error_log.rs
+++ b/tests/error_log.rs
@@ -1,7 +1,6 @@
 use expect_test::expect;
 use indoc::indoc;
 
-use test_harness::fs;
 use test_harness::test;
 use test_harness::BaseMatcher;
 use test_harness::GhcVersion::*;
@@ -21,7 +20,9 @@ async fn can_write_error_log() {
         .wait_until_ready()
         .await
         .expect("ghciwatch loads ghci");
-    let error_contents = fs::read(&error_path)
+    let error_contents = session
+        .fs()
+        .read(&error_path)
         .await
         .expect("ghciwatch writes ghcid.txt");
     expect![[r#"
@@ -49,17 +50,19 @@ async fn can_write_error_log_compilation_errors() {
 
     let new_module = session.path("src/My/Module.hs");
 
-    fs::write(
-        &new_module,
-        indoc!(
-            "module My.Module (myIdent) where
+    session
+        .fs()
+        .write(
+            &new_module,
+            indoc!(
+                "module My.Module (myIdent) where
             myIdent :: ()
             myIdent = \"Uh oh!\"
             "
-        ),
-    )
-    .await
-    .unwrap();
+            ),
+        )
+        .await
+        .unwrap();
     session
         .wait_until_add()
         .await
@@ -70,7 +73,9 @@ async fn can_write_error_log_compilation_errors() {
         .await
         .expect("ghciwatch writes ghcid.txt");
 
-    let error_contents = fs::read(&error_path)
+    let error_contents = session
+        .fs()
+        .read(&error_path)
         .await
         .expect("ghciwatch writes ghcid.txt");
 
@@ -101,7 +106,9 @@ async fn can_write_error_log_compilation_errors() {
 
     expected.assert_eq(&error_contents);
 
-    fs::replace(&new_module, "myIdent = \"Uh oh!\"", "myIdent = ()")
+    session
+        .fs()
+        .replace(&new_module, "myIdent = \"Uh oh!\"", "myIdent = ()")
         .await
         .unwrap();
 
@@ -115,7 +122,9 @@ async fn can_write_error_log_compilation_errors() {
         .await
         .expect("ghciwatch writes ghcid.txt");
 
-    let error_contents = fs::read(&error_path)
+    let error_contents = session
+        .fs()
+        .read(&error_path)
         .await
         .expect("ghciwatch writes ghcid.txt");
 

--- a/tests/failed_modules.rs
+++ b/tests/failed_modules.rs
@@ -1,5 +1,5 @@
-use test_harness::fs;
 use test_harness::test;
+use test_harness::Fs;
 use test_harness::GhciWatchBuilder;
 
 /// Test that `ghciwatch` can start with compile errors.
@@ -10,7 +10,9 @@ async fn can_start_with_failed_modules() {
     let module_path = "src/MyModule.hs";
     let mut session = GhciWatchBuilder::new("tests/data/simple")
         .before_start(move |path| async move {
-            fs::replace(path.join(module_path), "example :: String", "example :: ()").await
+            Fs::new()
+                .replace(path.join(module_path), "example :: String", "example :: ()")
+                .await
         })
         .start()
         .await
@@ -24,7 +26,9 @@ async fn can_start_with_failed_modules() {
 
     session.wait_until_ready().await.expect("ghciwatch loads");
 
-    fs::replace(&module_path, "example :: ()", "example :: String")
+    session
+        .fs()
+        .replace(&module_path, "example :: ()", "example :: String")
         .await
         .unwrap();
 

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-use test_harness::fs;
 use test_harness::test;
 use test_harness::BaseMatcher;
 use test_harness::GhciWatchBuilder;
@@ -66,7 +65,9 @@ async fn can_run_hooks() {
         )
         .await
         .unwrap();
-    fs::wait_for_path(wait_duration, &session.path("before-startup-shell-1"))
+    session
+        .fs()
+        .wait_for_path(wait_duration, &session.path("before-startup-shell-1"))
         .await
         .unwrap();
 
@@ -77,7 +78,9 @@ async fn can_run_hooks() {
         )
         .await
         .unwrap();
-    fs::wait_for_path(wait_duration, &session.path("before-startup-shell-2"))
+    session
+        .fs()
+        .wait_for_path(wait_duration, &session.path("before-startup-shell-2"))
         .await
         .unwrap();
 
@@ -107,7 +110,11 @@ async fn can_run_hooks() {
 
     session.wait_until_ready().await.unwrap();
 
-    fs::touch(session.path("src/MyLib.hs")).await.unwrap();
+    session
+        .fs()
+        .touch(session.path("src/MyLib.hs"))
+        .await
+        .unwrap();
 
     // Before reload
     session
@@ -166,7 +173,9 @@ async fn can_run_hooks() {
         )
         .await
         .unwrap();
-    fs::wait_for_path(wait_duration, &session.path("before-startup-shell-1"))
+    session
+        .fs()
+        .wait_for_path(wait_duration, &session.path("before-startup-shell-1"))
         .await
         .unwrap();
 
@@ -177,11 +186,17 @@ async fn can_run_hooks() {
         )
         .await
         .unwrap();
-    fs::wait_for_path(wait_duration, &session.path("before-startup-shell-2"))
+    session
+        .fs()
+        .wait_for_path(wait_duration, &session.path("before-startup-shell-2"))
         .await
         .unwrap();
 
-    fs::remove(session.path("src/MyModule.hs")).await.unwrap();
+    session
+        .fs()
+        .remove(session.path("src/MyModule.hs"))
+        .await
+        .unwrap();
     // Before restart
     session
         .wait_for_log(
@@ -239,7 +254,9 @@ async fn can_run_hooks() {
         )
         .await
         .unwrap();
-    fs::wait_for_path(wait_duration, &session.path("after-restart-shell-1"))
+    session
+        .fs()
+        .wait_for_path(wait_duration, &session.path("after-restart-shell-1"))
         .await
         .unwrap();
 
@@ -250,7 +267,9 @@ async fn can_run_hooks() {
         )
         .await
         .unwrap();
-    fs::wait_for_path(wait_duration, &session.path("after-restart-shell-2"))
+    session
+        .fs()
+        .wait_for_path(wait_duration, &session.path("after-restart-shell-2"))
         .await
         .unwrap();
 }

--- a/tests/load.rs
+++ b/tests/load.rs
@@ -1,6 +1,5 @@
 use indoc::indoc;
 
-use test_harness::fs;
 use test_harness::test;
 use test_harness::GhciWatch;
 
@@ -26,17 +25,19 @@ async fn can_load_new_module() {
         .wait_until_ready()
         .await
         .expect("ghciwatch loads ghci");
-    fs::write(
-        session.path("src/My/Module.hs"),
-        indoc!(
-            "module My.Module (myIdent) where
+    session
+        .fs()
+        .write(
+            session.path("src/My/Module.hs"),
+            indoc!(
+                "module My.Module (myIdent) where
             myIdent :: ()
             myIdent = ()
             "
-        ),
-    )
-    .await
-    .unwrap();
+            ),
+        )
+        .await
+        .unwrap();
     session
         .wait_until_add()
         .await

--- a/tests/reload.rs
+++ b/tests/reload.rs
@@ -1,6 +1,5 @@
 use indoc::indoc;
 
-use test_harness::fs;
 use test_harness::test;
 use test_harness::BaseMatcher;
 use test_harness::GhciWatch;
@@ -15,18 +14,20 @@ async fn can_reload() {
         .wait_until_ready()
         .await
         .expect("ghciwatch loads ghci");
-    fs::append(
-        session.path("src/MyLib.hs"),
-        indoc!(
-            "
+    session
+        .fs()
+        .append(
+            session.path("src/MyLib.hs"),
+            indoc!(
+                "
 
             hello = 1 :: Integer
 
             "
-        ),
-    )
-    .await
-    .unwrap();
+            ),
+        )
+        .await
+        .unwrap();
     session
         .wait_until_reload()
         .await
@@ -49,17 +50,19 @@ async fn can_reload_after_error() {
         .expect("ghciwatch loads ghci");
     let new_module = session.path("src/My/Module.hs");
 
-    fs::write(
-        &new_module,
-        indoc!(
-            "module My.Module (myIdent) where
+    session
+        .fs()
+        .write(
+            &new_module,
+            indoc!(
+                "module My.Module (myIdent) where
             myIdent :: ()
             myIdent = \"Uh oh!\"
             "
-        ),
-    )
-    .await
-    .unwrap();
+            ),
+        )
+        .await
+        .unwrap();
     session
         .wait_until_add()
         .await
@@ -69,7 +72,9 @@ async fn can_reload_after_error() {
         .await
         .unwrap();
 
-    fs::replace(&new_module, "myIdent = \"Uh oh!\"", "myIdent = ()")
+    session
+        .fs()
+        .replace(&new_module, "myIdent = \"Uh oh!\"", "myIdent = ()")
         .await
         .unwrap();
 

--- a/tests/rename.rs
+++ b/tests/rename.rs
@@ -1,4 +1,3 @@
-use test_harness::fs;
 use test_harness::test;
 use test_harness::BaseMatcher;
 use test_harness::GhciWatch;
@@ -17,7 +16,11 @@ async fn can_compile_renamed_module() {
 
     let module_path = session.path("src/MyModule.hs");
     let new_module_path = session.path("src/MyCoolModule.hs");
-    fs::rename(&module_path, &new_module_path).await.unwrap();
+    session
+        .fs()
+        .rename(&module_path, &new_module_path)
+        .await
+        .unwrap();
 
     session
         .wait_until_restart()
@@ -29,7 +32,9 @@ async fn can_compile_renamed_module() {
         .await
         .unwrap();
 
-    fs::replace(new_module_path, "module MyModule", "module MyCoolModule")
+    session
+        .fs()
+        .replace(new_module_path, "module MyModule", "module MyCoolModule")
         .await
         .unwrap();
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,4 @@
 use expect_test::expect;
-use test_harness::fs;
 use test_harness::test;
 use test_harness::BaseMatcher;
 use test_harness::GhciWatchBuilder;
@@ -19,7 +18,9 @@ async fn can_run_test_suite_on_reload() {
         .await
         .expect("ghciwatch loads ghci");
 
-    fs::touch(session.path("src/MyLib.hs"))
+    session
+        .fs()
+        .touch(session.path("src/MyLib.hs"))
         .await
         .expect("Can touch file");
 
@@ -32,7 +33,9 @@ async fn can_run_test_suite_on_reload() {
         .await
         .expect("ghciwatch runs the test suite");
 
-    let error_contents = fs::read(&error_path)
+    let error_contents = session
+        .fs()
+        .read(&error_path)
         .await
         .expect("ghciwatch writes ghcid.txt");
     expect![[r#"


### PR DESCRIPTION
The test suite features a load-bearing sleep of 1 second before writing. This makes the filesystem events get detected more reliably, for whatever reason.

This change allows disabling the load-bearing sleeps; this is typically needed to make several writes that all get detected together by `ghciwatch`.