### PR TITLE
Store lifecycle hooks dynamically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,18 +19,18 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.4"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anstream"
-version = "0.5.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -42,15 +42,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
 dependencies = [
  "utf8parse",
 ]
@@ -66,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "2.1.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -82,7 +82,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -145,15 +145,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "bstr"
-version = "1.6.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2f7349907b712260e64b0afe2f84692af14a454be26187d9df565c7f69266a"
+checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
 dependencies = [
  "memchr",
  "serde",
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "camino"
@@ -188,45 +188,44 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.1"
+version = "4.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c8d502cbaec4595d2e7d5f61e318f05417bd2b66fdc3809498f0d3fdf0bea27"
+checksum = "2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64"
 dependencies = [
  "clap_builder",
  "clap_derive",
- "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.1"
+version = "4.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5891c7bc0edb3e1c2204fc5e94009affabeb1821c9e5fdc3959536c5c0bb984d"
+checksum = "07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
- "terminal_size 0.2.6",
+ "terminal_size 0.3.0",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.4.0"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9fd1a5729c4548118d7d70ff234a44868d00489a4b6597b0b020918a0e91a1a"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "colorchoice"
@@ -267,9 +266,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "diff"
@@ -291,23 +293,12 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "errno"
-version = "0.3.2"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
 dependencies = [
- "errno-dragonfly",
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -322,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "file-id"
@@ -343,7 +334,7 @@ checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "windows-sys",
 ]
 
@@ -370,32 +361,32 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
  "futures-core",
  "futures-macro",
@@ -407,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "libc",
@@ -442,6 +433,7 @@ dependencies = [
  "regex",
  "shell-words",
  "strip-ansi-escapes",
+ "strum",
  "tap",
  "test-harness",
  "textwrap 0.16.0",
@@ -450,6 +442,7 @@ dependencies = [
  "tracing-human-layer",
  "tracing-subscriber",
  "tracing-test",
+ "unindent",
  "winnow",
 ]
 
@@ -489,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "humantime"
@@ -557,7 +550,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi 0.3.3",
  "libc",
  "windows-sys",
 ]
@@ -568,8 +561,8 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.2",
- "rustix 0.38.10",
+ "hermit-abi 0.3.3",
+ "rustix 0.38.25",
  "windows-sys",
 ]
 
@@ -622,9 +615,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "line-span"
@@ -640,15 +633,15 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -671,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.3"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "miette"
@@ -687,7 +680,7 @@ dependencies = [
  "miette-derive",
  "once_cell",
  "owo-colors",
- "supports-color 2.0.0",
+ "supports-color 2.1.0",
  "supports-hyperlinks",
  "supports-unicode",
  "terminal_size 0.1.17",
@@ -704,7 +697,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -718,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "log",
@@ -745,7 +738,7 @@ version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -788,15 +781,15 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi 0.3.3",
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "memchr",
 ]
@@ -834,13 +827,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "smallvec",
  "windows-targets",
 ]
@@ -885,6 +878,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -902,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -958,15 +957,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.9.4"
+name = "redox_syscall"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "regex"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.7",
- "regex-syntax 0.7.5",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -980,13 +988,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.7"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -997,9 +1005,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rustc-demangle"
@@ -1009,9 +1017,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.37.23"
+version = "0.37.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -1023,16 +1031,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.10"
+version = "0.38.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6248e1caa625eb708e266e06159f135e8c26f2bb7ceb72dc4b2766d0340964"
+checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "errno",
  "libc",
- "linux-raw-sys 0.4.5",
+ "linux-raw-sys 0.4.11",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
@@ -1057,29 +1071,29 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.105"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -1088,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
@@ -1121,21 +1135,21 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "smawk"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys",
@@ -1157,6 +1171,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "supports-color"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,9 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "supports-color"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4950e7174bffabe99455511c39707310e7e9b440364a2fcb1cc21521be57b354"
+checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
 dependencies = [
  "is-terminal",
  "is_ci",
@@ -1207,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1224,14 +1260,14 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.8.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
- "rustix 0.38.10",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.25",
  "windows-sys",
 ]
 
@@ -1251,7 +1287,17 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
 dependencies = [
- "rustix 0.37.23",
+ "rustix 0.37.27",
+ "windows-sys",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix 0.38.25",
  "windows-sys",
 ]
 
@@ -1281,7 +1327,7 @@ name = "test-harness-macro"
 version = "0.1.0"
 dependencies = [
  "quote",
- "syn 2.0.29",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1315,22 +1361,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.47"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.47"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1345,12 +1391,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
  "deranged",
  "itoa",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -1358,24 +1405,24 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
 dependencies = [
  "time-core",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1393,22 +1440,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1416,20 +1462,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1437,9 +1483,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-human-layer"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e552097b90425f04e1118d96002b49404a5f8f78040ee8d58eefa97b146731f"
+checksum = "4f535a660245c04f845c9b0059fc48442f368fdfbc590ed3c4207a09945de70b"
 dependencies = [
  "itertools",
  "owo-colors",
@@ -1450,12 +1496,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "lazy_static",
  "log",
+ "once_cell",
  "tracing-core",
 ]
 
@@ -1471,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -1516,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-linebreak"
@@ -1528,9 +1574,15 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "unindent"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "utf8parse"
@@ -1566,9 +1618,9 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -1598,9 +1650,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi",
 ]
@@ -1679,9 +1731,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.15"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
+checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "enum-iterator"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7add3873b5dd076766ee79c8e406ad1a472c385476b9e38849f8eec24f1be689"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eecf8589574ce9b895052fa12d69af7a233f99e6107f5cb8dd1044f2a17bfdcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +436,7 @@ dependencies = [
  "camino",
  "clap",
  "command-group",
+ "enum-iterator",
  "expect-test",
  "humantime",
  "ignore",
@@ -433,7 +454,6 @@ dependencies = [
  "regex",
  "shell-words",
  "strip-ansi-escapes",
- "strum",
  "tap",
  "test-harness",
  "textwrap 0.16.0",
@@ -1043,12 +1063,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
-
-[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,28 +1183,6 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strum"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.39",
-]
 
 [[package]]
 name = "supports-color"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,10 @@ backoff = { version = "0.4.0", default-features = false }
 camino = "1.1.4"
 clap = { version = "4.3.2", features = ["derive", "wrap_help", "env", "string"] }
 command-group = { version = "2.1.0", features = ["tokio", "with-tokio"] }
+enum-iterator = "1.4.1"
 humantime = "2.1.0"
 ignore = "0.4.20"
+indoc = "1.0.6"
 itertools = "0.11.0"
 line-span = "0.1.5"
 miette = { version = "5.9.0", features = ["fancy"] }
@@ -52,7 +54,6 @@ pathdiff = { version = "0.2.1", features = ["camino"] }
 regex = { version = "1.9.3", default-features = false, features = ["perf", "std"] }
 shell-words = "1.1.0"
 strip-ansi-escapes = "0.2.0"
-strum = { version = "0.25.0", features = ["derive"] }
 tap = "1.0.1"
 textwrap = { version = "0.16.0", features = ["terminal_size"] }
 tokio = { version = "1.28.2", features = ["full", "tracing"] }
@@ -65,7 +66,6 @@ winnow = "0.5.15"
 [dev-dependencies]
 test-harness = { path = "test-harness" }
 expect-test = "1.4.0"
-indoc = "1.0.6"
 pretty_assertions = "1.2.1"
 tracing-test = { version = "0.2", features = ["no-env-filter"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ categories = ["command-line-utilities", "development-tools"]
 aho-corasick = "1.0.2"
 backoff = { version = "0.4.0", default-features = false }
 camino = "1.1.4"
-clap = { version = "4.3.2", features = ["derive", "wrap_help", "env"] }
+clap = { version = "4.3.2", features = ["derive", "wrap_help", "env", "string"] }
 command-group = { version = "2.1.0", features = ["tokio", "with-tokio"] }
 humantime = "2.1.0"
 ignore = "0.4.20"
@@ -52,12 +52,14 @@ pathdiff = { version = "0.2.1", features = ["camino"] }
 regex = { version = "1.9.3", default-features = false, features = ["perf", "std"] }
 shell-words = "1.1.0"
 strip-ansi-escapes = "0.2.0"
+strum = { version = "0.25.0", features = ["derive"] }
 tap = "1.0.1"
 textwrap = { version = "0.16.0", features = ["terminal_size"] }
 tokio = { version = "1.28.2", features = ["full", "tracing"] }
 tracing = "0.1.37"
 tracing-human-layer = "0.1.0"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "time", "json", "registry"] }
+unindent = "0.2.3"
 winnow = "0.5.15"
 
 [dev-dependencies]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,9 +11,7 @@ use tracing_subscriber::fmt::format::FmtSpan;
 use crate::clap::FmtSpanParserFactory;
 use crate::clap::RustBacktrace;
 use crate::clonable_command::ClonableCommand;
-use crate::ghci::GhciCommand;
 use crate::ignore::GlobMatcher;
-use crate::maybe_async_command::MaybeAsyncCommand;
 use crate::normal_path::NormalPath;
 
 /// A `ghci`-based file watcher and Haskell recompiler.
@@ -42,7 +40,7 @@ pub struct Opts {
 
     /// Lifecycle hooks and commands to run at various points.
     #[command(flatten)]
-    pub hooks: HookOpts,
+    pub hooks: crate::hooks::HookOpts,
 
     /// Options to modify file watching.
     #[command(flatten)]
@@ -159,86 +157,6 @@ pub struct LoggingOpts {
     /// Path to write JSON logs to.
     #[arg(long, value_name = "PATH")]
     pub log_json: Option<Utf8PathBuf>,
-}
-
-/// Lifecycle hooks.
-///
-/// These are commands (mostly `ghci` commands) to run at various points in the `ghciwatch`
-/// lifecycle.
-#[derive(Debug, Clone, clap::Args)]
-#[clap(next_help_heading = "Lifecycle hooks")]
-pub struct HookOpts {
-    /// `ghci` commands which runs tests, like `TestMain.testMain`. If given, these commands will be
-    /// run after reloads.
-    /// Can be given multiple times.
-    #[arg(long, value_name = "GHCI_COMMAND")]
-    pub test_ghci: Vec<GhciCommand>,
-
-    /// Shell commands to run before starting or restarting `ghci`.
-    ///
-    /// This can be used to regenerate `.cabal` files with `hpack`.
-    /// Can be given multiple times.
-    #[arg(long, value_name = "SHELL_COMMAND")]
-    pub before_startup_shell: Vec<MaybeAsyncCommand>,
-
-    /// `ghci` commands to run on startup. Use `:set args ...` in combination with `--test` to set
-    /// the command-line arguments for tests.
-    /// Can be given multiple times.
-    #[arg(long, value_name = "GHCI_COMMAND")]
-    pub after_startup_ghci: Vec<GhciCommand>,
-
-    /// `ghci` commands to run before reloading `ghci`.
-    ///
-    /// These are run when modules are change on disk; this does not necessarily correspond to a
-    /// `:reload` command.
-    /// Can be given multiple times.
-    #[arg(long, value_name = "GHCI_COMMAND")]
-    pub before_reload_ghci: Vec<GhciCommand>,
-
-    /// Shell commands to run before reloading `ghci`.
-    ///
-    /// Can be given multiple times.
-    #[arg(long, value_name = "SHELL_COMMAND")]
-    pub before_reload_shell: Vec<MaybeAsyncCommand>,
-
-    /// `ghci` commands to run after reloading `ghci`.
-    /// Can be given multiple times.
-    #[arg(long, value_name = "GHCI_COMMAND")]
-    pub after_reload_ghci: Vec<GhciCommand>,
-
-    /// Shell commands to run after reloading `ghci`.
-    /// Can be given multiple times.
-    #[arg(long, value_name = "SHELL_COMMAND")]
-    pub after_reload_shell: Vec<MaybeAsyncCommand>,
-
-    /// `ghci` commands to run before restarting `ghci`.
-    ///
-    /// See `--after-restart-ghci` for more details.
-    /// Can be given multiple times.
-    #[arg(long, value_name = "GHCI_COMMAND")]
-    pub before_restart_ghci: Vec<GhciCommand>,
-
-    /// Shell commands to run before restarting `ghci`.
-    /// Can be given multiple times.
-    #[arg(long, value_name = "SHELL_COMMAND")]
-    pub before_restart_shell: Vec<MaybeAsyncCommand>,
-
-    /// `ghci` commands to run after restarting `ghci`.
-    /// Can be given multiple times.
-    ///
-    /// `ghci` cannot reload after files are deleted due to a bug, so `ghciwatch` has to restart the
-    /// underlying `ghci` session when this happens. Note that the `--before-restart-ghci` and
-    /// `--after-restart-ghci` commands will therefore run in different `ghci` sessions without
-    /// shared context.
-    ///
-    /// See: https://gitlab.haskell.org/ghc/ghc/-/issues/9648
-    #[arg(long, value_name = "GHCI_COMMAND")]
-    pub after_restart_ghci: Vec<GhciCommand>,
-
-    /// Shell commands to run after restarting `ghci`.
-    /// Can be given multiple times.
-    #[arg(long, value_name = "SHELL_COMMAND")]
-    pub after_restart_shell: Vec<MaybeAsyncCommand>,
 }
 
 impl Opts {

--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -58,12 +58,14 @@ pub use ghci_command::GhciCommand;
 
 use crate::aho_corasick::AhoCorasickExt;
 use crate::buffers::LINE_BUFFER_CAPACITY;
-use crate::cli::HookOpts;
 use crate::cli::Opts;
 use crate::clonable_command::ClonableCommand;
 use crate::event_filter::FileEvent;
 use crate::format_bulleted_list;
 use crate::haskell_source_file::is_haskell_source_file;
+use crate::hooks;
+use crate::hooks::HookOpts;
+use crate::hooks::LifecycleEvent;
 use crate::ignore::GlobMatcher;
 use crate::incremental_reader::IncrementalReader;
 use crate::normal_path::NormalPath;
@@ -179,10 +181,13 @@ impl Ghci {
         {
             let span = tracing::debug_span!("before_startup_shell");
             let _enter = span.enter();
-            for command in &opts.hooks.before_startup_shell {
-                tracing::info!(%command, "Running before-startup command");
-                command.run_on(&mut command_handles).await?;
-            }
+            opts.hooks
+                .run_shell_hooks(
+                    LifecycleEvent::Startup,
+                    hooks::When::Before,
+                    &mut command_handles,
+                )
+                .await?;
         }
 
         let mut group = {
@@ -293,11 +298,10 @@ impl Ghci {
         self.stdout.initialize().await?;
 
         // Perform start-of-session initialization.
-        let messages = self
-            .stdin
-            .initialize(&mut self.stdout, &self.opts.hooks.after_startup_ghci)
-            .await?;
+        let messages = self.stdin.initialize(&mut self.stdout).await?;
         self.process_ghc_messages(messages).await?;
+        self.run_hooks(LifecycleEvent::Startup, hooks::When::After)
+            .await?;
 
         // Get the initial list of targets.
         self.refresh_targets().await?;
@@ -423,14 +427,8 @@ impl Ghci {
         }
 
         if actions.needs_add_or_reload() {
-            for command in &self.opts.hooks.before_reload_shell {
-                tracing::info!(%command, "Running before-reload command");
-                command.run_on(&mut self.command_handles).await?;
-            }
-            for command in &self.opts.hooks.before_reload_ghci {
-                tracing::info!(%command, "Running before-reload command");
-                self.stdin.run_command(&mut self.stdout, command).await?;
-            }
+            self.run_hooks(LifecycleEvent::Reload, hooks::When::Before)
+                .await?;
         }
 
         let mut compilation_failed = false;
@@ -462,14 +460,8 @@ impl Ghci {
         }
 
         if actions.needs_add_or_reload() {
-            for command in &self.opts.hooks.after_reload_shell {
-                tracing::info!(%command, "Running after-reload command");
-                command.run_on(&mut self.command_handles).await?;
-            }
-            for command in &self.opts.hooks.after_reload_ghci {
-                tracing::info!(%command, "Running after-reload command");
-                self.stdin.run_command(&mut self.stdout, command).await?;
-            }
+            self.run_hooks(LifecycleEvent::Reload, hooks::When::After)
+                .await?;
 
             if compilation_failed {
                 tracing::debug!("Compilation failed, skipping running tests.");
@@ -488,34 +480,22 @@ impl Ghci {
     /// Restart the `ghci` session.
     #[instrument(skip_all, level = "debug")]
     async fn restart(&mut self) -> miette::Result<()> {
-        for command in &self.opts.hooks.before_restart_shell {
-            tracing::info!(%command, "Running before-restart command");
-            command.run_on(&mut self.command_handles).await?;
-        }
-        for command in &self.opts.hooks.before_restart_ghci {
-            tracing::info!(%command, "Running before-restart command");
-            self.stdin.run_command(&mut self.stdout, command).await?;
-        }
+        self.run_hooks(LifecycleEvent::Restart, hooks::When::Before)
+            .await?;
         self.stop().await?;
         let new = Self::new(self.shutdown.clone(), self.opts.clone()).await?;
         let _ = std::mem::replace(self, new);
         self.initialize().await?;
-        for command in &self.opts.hooks.after_restart_shell {
-            tracing::info!(%command, "Running after-restart command");
-            command.run_on(&mut self.command_handles).await?;
-        }
-        for command in &self.opts.hooks.after_restart_ghci {
-            tracing::info!(%command, "Running after-restart command");
-            self.stdin.run_command(&mut self.stdout, command).await?;
-        }
+        self.run_hooks(LifecycleEvent::Restart, hooks::When::After)
+            .await?;
         Ok(())
     }
 
     /// Run the user provided test command.
     #[instrument(skip_all, level = "debug")]
     async fn test(&mut self) -> miette::Result<()> {
-        self.stdin
-            .test(&mut self.stdout, &self.opts.hooks.test_ghci)
+        self.stdin.set_mode(&mut self.stdout, Mode::Testing).await?;
+        self.run_hooks(LifecycleEvent::Test, hooks::When::During)
             .await?;
         Ok(())
     }
@@ -729,6 +709,27 @@ impl Ghci {
     #[instrument(skip_all, level = "trace")]
     fn prune_command_handles(&mut self) {
         self.command_handles.retain(|handle| !handle.is_finished());
+    }
+
+    #[instrument(skip(self), level = "trace")]
+    async fn run_hooks(&mut self, event: LifecycleEvent, when: hooks::When) -> miette::Result<()> {
+        for hook in self.opts.hooks.select(event, when) {
+            tracing::info!(command = %hook.command, "Running {hook} command");
+            match &hook.command {
+                hooks::Command::Ghci(command) => {
+                    let start_time = Instant::now();
+                    self.stdin.run_command(&mut self.stdout, command).await?;
+                    if let LifecycleEvent::Test = &hook.event {
+                        tracing::info!("Finished running tests in {:.2?}", start_time.elapsed());
+                    }
+                }
+                hooks::Command::Shell(command) => {
+                    command.run_on(&mut self.command_handles).await?;
+                }
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/src/ghci/parse/haskell_grammar.rs
+++ b/src/ghci/parse/haskell_grammar.rs
@@ -4,7 +4,7 @@
 //!
 //! [1]: https://www.haskell.org/onlinereport/haskell2010/haskellch2.html
 
-use winnow::combinator::separated1;
+use winnow::combinator::separated;
 use winnow::token::one_of;
 use winnow::token::take_while;
 use winnow::PResult;
@@ -15,7 +15,7 @@ use winnow::Parser;
 /// See: `modid` in <https://www.haskell.org/onlinereport/haskell2010/haskellch2.html#x7-180002.4>
 pub fn module_name<'i>(input: &mut &'i str) -> PResult<&'i str> {
     // Surely there's a better way to get type inference to work here?
-    separated1::<_, _, (), _, _, _, _>(constructor_name, ".")
+    separated::<_, _, (), _, _, _, _>(1.., constructor_name, ".")
         .recognize()
         .parse_next(input)
 }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,0 +1,393 @@
+//! Lifecycle hooks.
+
+use std::fmt::Display;
+use std::process::ExitStatus;
+use std::str::FromStr;
+
+use clap::builder::ValueParserFactory;
+use clap::Arg;
+use clap::ArgAction;
+use clap::Args;
+use clap::FromArgMatches;
+use strum::EnumMessage;
+use strum::EnumProperty;
+use strum::IntoEnumIterator;
+use tokio::task::JoinHandle;
+
+use crate::ghci::GhciCommand;
+use crate::maybe_async_command::MaybeAsyncCommand;
+
+/// A lifecycle event that triggers hooks.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    strum::EnumVariantNames,
+    strum::EnumIter,
+    strum::EnumMessage,
+    strum::EnumProperty,
+    strum::Display,
+    strum::AsRefStr,
+)]
+#[strum(serialize_all = "kebab-case")]
+pub enum LifecycleEvent {
+    /// When tests are run (after startup, after reloads).
+    #[strum(
+        message = "
+        Tests are run after startup and after reloads.
+        ",
+        props(help_name = "tests")
+    )]
+    Test,
+    /// When a `ghci` session is started (at `ghciwatch` startup and after restarts).
+    #[strum(message = "
+        Startup hooks run when `ghci` is started (at `ghciwatch` startup and after `ghci` restarts).
+    ")]
+    Startup,
+    /// When a module is changed or added.
+    #[strum(message = "
+        Reload hooks are run when modules are changed on disk.
+    ")]
+    Reload,
+    /// When a `ghci` session is restarted (when a module is removed or renamed).
+    #[strum(message = "
+        `ghci` is restarted when modules are removed or renamed.
+        See: https://gitlab.haskell.org/ghc/ghc/-/issues/11596
+    ")]
+    Restart,
+}
+
+impl LifecycleEvent {
+    fn supported_when(&self) -> Vec<When> {
+        match self {
+            LifecycleEvent::Test => vec![When::During],
+            LifecycleEvent::Startup | LifecycleEvent::Reload | LifecycleEvent::Restart => {
+                vec![When::Before, When::After]
+            }
+        }
+    }
+
+    fn supported_kind(&self, when: When) -> Vec<CommandKind> {
+        debug_assert!(self.supported_when().contains(&when));
+        match self {
+            LifecycleEvent::Reload | LifecycleEvent::Restart | LifecycleEvent::Test => {
+                vec![CommandKind::Ghci, CommandKind::Shell]
+            }
+            LifecycleEvent::Startup => match when {
+                When::Before => vec![CommandKind::Shell],
+                When::During => unreachable!(),
+                When::After => vec![CommandKind::Ghci, CommandKind::Shell],
+            },
+        }
+    }
+
+    fn hooks() -> impl Iterator<Item = Hook<CommandKind>> {
+        Self::iter()
+            .flat_map(|event| {
+                event
+                    .supported_when()
+                    .into_iter()
+                    .map(move |when| (event, when))
+            })
+            .flat_map(|(event, when)| {
+                event
+                    .supported_kind(when)
+                    .into_iter()
+                    .map(move |kind| Hook {
+                        event,
+                        when,
+                        command: kind,
+                    })
+            })
+    }
+}
+
+/// When to run a hook in relation to a given [`LifecycleEvent`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, strum::AsRefStr)]
+#[strum(serialize_all = "kebab-case")]
+pub enum When {
+    /// Run the hook before the event.
+    Before,
+    /// Run the hook at the event.
+    ///
+    /// This is used for the test hook.
+    During,
+    /// Run the hook after the event.
+    After,
+}
+
+/// The kind of hook; a `ghci` command or a shell command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, strum::Display, strum::AsRefStr)]
+#[strum(serialize_all = "kebab-case")]
+pub enum CommandKind {
+    /// A shell command.
+    Shell,
+    /// A `ghci` command.
+    ///
+    /// Can either be Haskell code to run (`TestMain.test`) or a `ghci` command (`:set args ...`).
+    Ghci,
+}
+
+impl CommandKind {
+    fn placeholder_name(&self) -> &'static str {
+        match self {
+            CommandKind::Ghci => "GHCI_CMD",
+            CommandKind::Shell => "SHELL_CMD",
+        }
+    }
+}
+
+/// A command to run for a hook.
+#[derive(Debug, Clone)]
+pub enum Command {
+    /// A shell command.
+    Shell(MaybeAsyncCommand),
+    /// A `ghci` command.
+    Ghci(GhciCommand),
+}
+
+impl Command {
+    fn kind(&self) -> CommandKind {
+        match self {
+            Command::Ghci(_) => CommandKind::Ghci,
+            Command::Shell(_) => CommandKind::Shell,
+        }
+    }
+}
+
+impl Display for Command {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Command::Ghci(command) => command.fmt(f),
+            Command::Shell(command) => command.fmt(f),
+        }
+    }
+}
+
+/// A lifecycle hook, specifying a command to run and an event to run it at.
+#[derive(Debug, Clone)]
+pub struct Hook<C> {
+    /// The event to run this hook on.
+    pub event: LifecycleEvent,
+    /// When to run the hook in relation to the event.
+    pub when: When,
+    /// The command to run.
+    pub command: C,
+}
+
+impl<C> Display for Hook<C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.when {
+            When::During => write!(f, "{}", self.event.as_ref()),
+            _ => write!(f, "{}-{}", self.when, self.event),
+        }
+    }
+}
+
+impl<C> Hook<C> {
+    fn with_command<C2>(&self, command: C2) -> Hook<C2> {
+        Hook {
+            event: self.event,
+            when: self.when,
+            command,
+        }
+    }
+}
+
+impl Hook<CommandKind> {
+    fn extra_help(&self) -> Option<&'static str> {
+        match (self.event, self.when, self.command) {
+            (LifecycleEvent::Startup, When::Before, _) => Some(
+                "
+                This can be used to regenerate `.cabal` files with `hpack`.
+                ",
+            ),
+            (LifecycleEvent::Startup, When::After, CommandKind::Ghci) => Some(
+                "
+                Use `:set args ...` to set command-line arguments for test hooks.
+                ",
+            ),
+            (LifecycleEvent::Test, _, CommandKind::Ghci) => Some(
+                "
+                Example: `TestMain.testMain`.
+                ",
+            ),
+            _ => None,
+        }
+    }
+
+    fn arg_name(&self) -> String {
+        let mut ret = match self.when {
+            When::During => String::new(),
+            when => when.to_string(),
+        };
+        if !ret.is_empty() {
+            ret.push('-');
+        }
+        ret.push_str(self.event.as_ref());
+        ret.push('-');
+        ret.push_str(self.command.as_ref());
+        ret
+    }
+
+    fn help(&self) -> Help {
+        let Hook {
+            event,
+            when,
+            command,
+        } = self;
+        let kind = match command {
+            CommandKind::Ghci => "`ghci`",
+            CommandKind::Shell => "Shell",
+        };
+
+        let mut short = format!("{kind} commands to run");
+
+        match when {
+            When::During => {}
+            _ => {
+                short.push(' ');
+                short.push_str(when.as_ref());
+            }
+        }
+
+        short.push(' ');
+        if let Some(help_name) = event.get_str("help_name") {
+            short.push_str(help_name);
+        } else {
+            short.push_str(event.as_ref());
+        }
+
+        let mut long = short.clone();
+
+        if let Some(message) = self.event.get_message() {
+            long.push_str("\n\n");
+            long.push_str(unindent::unindent(message).trim_end_matches('\n'));
+        }
+        if let Some(extra_help) = self.extra_help() {
+            long.push('\n');
+            long.push_str(unindent::unindent(extra_help).trim_end_matches('\n'));
+        }
+
+        long.push_str("\n\nCan be given multiple times.");
+
+        Help { short, long }
+    }
+}
+
+struct Help {
+    short: String,
+    long: String,
+}
+
+/// Lifecycle hooks.
+///
+/// These are `ghci` and shell commands to run at various points in the `ghciwatch`
+/// lifecycle.
+#[derive(Debug, Clone, Default)]
+pub struct HookOpts {
+    hooks: Vec<Hook<Command>>,
+}
+
+impl HookOpts {
+    pub fn select(
+        &self,
+        event: LifecycleEvent,
+        when: When,
+    ) -> impl Iterator<Item = &Hook<Command>> {
+        self.hooks
+            .iter()
+            .filter(move |hook| hook.event == event && hook.when == when)
+    }
+
+    pub async fn run_shell_hooks(
+        &self,
+        event: LifecycleEvent,
+        when: When,
+        handles: &mut Vec<JoinHandle<miette::Result<ExitStatus>>>,
+    ) -> miette::Result<()> {
+        for hook in self.select(event, when) {
+            if let Command::Shell(command) = &hook.command {
+                tracing::info!(%command, "Running {hook} command");
+                command.run_on(handles).await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Args for HookOpts {
+    fn augment_args(mut cmd: clap::Command) -> clap::Command {
+        for hook in LifecycleEvent::hooks() {
+            let name = hook.arg_name();
+            let help = hook.help();
+            let arg = Arg::new(&name)
+                .long(&name)
+                .action(ArgAction::Append)
+                .required(false)
+                .value_name(hook.command.placeholder_name())
+                .help(help.short)
+                .long_help(help.long)
+                .help_heading("Lifecycle hooks");
+
+            let arg = match hook.command {
+                CommandKind::Ghci => arg.value_parser(GhciCommand::value_parser()),
+                CommandKind::Shell => arg.value_parser(MaybeAsyncCommand::from_str),
+            };
+
+            cmd = cmd.arg(arg);
+        }
+        cmd
+    }
+
+    fn augment_args_for_update(cmd: clap::Command) -> clap::Command {
+        Self::augment_args(cmd)
+    }
+}
+
+impl FromArgMatches for HookOpts {
+    fn from_arg_matches(matches: &clap::ArgMatches) -> Result<Self, clap::Error> {
+        let mut ret = Self::default();
+        ret.update_from_arg_matches(matches)?;
+        Ok(ret)
+    }
+
+    fn update_from_arg_matches(&mut self, matches: &clap::ArgMatches) -> Result<(), clap::Error> {
+        for hook in LifecycleEvent::hooks() {
+            let name = hook.arg_name();
+            match hook.command {
+                CommandKind::Ghci => {
+                    self.hooks.extend(
+                        matches
+                            .get_many::<GhciCommand>(&name)
+                            .into_iter()
+                            .flatten()
+                            .map(|command| hook.with_command(Command::Ghci(command.clone()))),
+                    );
+                }
+                CommandKind::Shell => {
+                    self.hooks.extend(
+                        matches
+                            .get_many::<MaybeAsyncCommand>(&name)
+                            .into_iter()
+                            .flatten()
+                            .map(|command| hook.with_command(Command::Shell(command.clone()))),
+                    );
+                }
+            }
+        }
+
+        // Sort the hooks so that shell commands are first.
+        //
+        // Shell commands _may_ be asynchronous, but `ghci` commands are always synchronous, so we
+        // run shell commands first.
+        self.hooks
+            .sort_by(|a, b| a.command.kind().cmp(&b.command.kind()));
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ mod event_filter;
 mod format_bulleted_list;
 mod ghci;
 mod haskell_source_file;
+mod hooks;
 mod ignore;
 mod incremental_reader;
 mod maybe_async_command;


### PR DESCRIPTION
Instead of having a field for each event (`before_restart_ghci`, `test_ghci`, `after_startup_shell`, etc.), we generate and store the arguments dynamically. This simplifies the running of hooks and will hopefully make it easier to extend the lifecycle hooks in the future.