### PR TITLE
Don't print "All good!" when compilation is not "All good!"

### DIFF
--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -466,7 +466,7 @@ impl Ghci {
                 .await?;
 
             if compilation_failed {
-                tracing::debug!("Compilation failed, skipping running tests.");
+                tracing::debug!("Compilation failed, skipping running tests");
             } else {
                 tracing::info!(
                     "{} Finished reloading in {:.2?}",
@@ -670,7 +670,7 @@ impl Ghci {
 
         self.error_log.write(compilation_summary, &messages).await?;
 
-        Ok(None)
+        Ok(compilation_summary.map(|summary| summary.result))
     }
 
     /// Make a path relative to the `ghci` session's current working directory.

--- a/test-harness/src/matcher/base_matcher.rs
+++ b/test-harness/src/matcher/base_matcher.rs
@@ -13,6 +13,7 @@ use crate::Matcher;
 pub struct BaseMatcher {
     message: Regex,
     target: Option<String>,
+    leaf_span: Option<String>,
     spans: Vec<String>,
     fields: HashMap<String, Regex>,
 }
@@ -28,6 +29,7 @@ impl BaseMatcher {
         Self {
             message,
             target: None,
+            leaf_span: None,
             spans: Vec::new(),
             fields: HashMap::new(),
         }
@@ -46,13 +48,13 @@ impl BaseMatcher {
     /// Utility for constructing a matcher that waits until the inner `ghci` finishes compilation
     /// successfully.
     pub fn compilation_succeeded() -> Self {
-        Self::message("^Compilation succeeded$").in_span("reload")
+        Self::message("^Compilation succeeded$").in_leaf_span("reload")
     }
 
     /// Utility for constructing a matcher that waits until the inner `ghci` finishes compilation
     /// unsuccessfully.
     pub fn compilation_failed() -> Self {
-        Self::message("^Compilation failed$").in_span("reload")
+        Self::message("^Compilation failed$").in_leaf_span("reload")
     }
 
     /// Utility for constructing a matcher that waits until the inner `ghci` compiles the given
@@ -61,7 +63,7 @@ impl BaseMatcher {
     /// The module is given by name (`My.Module`), not path (`src/My/Module.hs`).
     pub fn module_compiling(module: &str) -> Self {
         Self::message("^Compiling$")
-            .in_span("reload")
+            .in_leaf_span("reload")
             .with_field("module", &regex::escape(module))
     }
 
@@ -75,7 +77,7 @@ impl BaseMatcher {
     /// adding modules. (E.g., if all the changed files are ignored, a 'reload' may be a no-op.)
     pub fn reload_completes() -> Self {
         Self::span_close()
-            .in_span("reload")
+            .in_leaf_span("reload")
             .in_module("ghciwatch::ghci")
     }
 
@@ -90,12 +92,14 @@ impl BaseMatcher {
         Self::message("^Restarting ghci:\n")
     }
 
-    /// Require that matching events be in a span with the given name.
+    /// Require that matching events be in a leaf span with the given name.
+    ///
+    /// A leaf span is the inner-most span; i.e. if you have an event in spans `c` (root),
+    /// `b`, and `a` (leaf), then `in_leaf_span("a")` will match but `in_leaf_span("b")` will not.
     ///
     /// Note that this will overwrite any previously-set spans.
-    pub fn in_span(mut self, span: &str) -> Self {
-        self.spans.clear();
-        self.spans.push(span.to_owned());
+    pub fn in_leaf_span(mut self, span: &str) -> Self {
+        self.leaf_span = Some(span.to_owned());
         self
     }
 
@@ -215,6 +219,17 @@ impl Matcher for BaseMatcher {
                             return Ok(false);
                         }
                     }
+                }
+            }
+        }
+
+        if let Some(leaf_span) = &self.leaf_span {
+            match event.spans().last() {
+                Some(actual_leaf_span) if &actual_leaf_span.name == leaf_span => {}
+                _ => {
+                    // Expected a leaf span, but the event is missing a leaf span or doesn't have
+                    // the correct leaf span.
+                    return Ok(false);
                 }
             }
         }
@@ -465,7 +480,7 @@ mod tests {
     #[test]
     fn test_matcher_in_span() {
         assert!(BaseMatcher::span_close()
-            .in_span("error_log_write")
+            .in_leaf_span("error_log_write")
             .matches(&Event {
                 timestamp: "2023-09-12T18:06:04.677942Z".into(),
                 level: Level::DEBUG,
@@ -486,6 +501,65 @@ mod tests {
                     .into(),
                 }),
                 spans: vec![Span::new("on_action"), Span::new("reload"),]
+            })
+            .unwrap());
+
+        assert!(BaseMatcher::span_close()
+            .in_leaf_span("error_log_write")
+            .matches(&Event {
+                timestamp: "2023-09-12T18:06:04.677942Z".into(),
+                level: Level::DEBUG,
+                message: "close".into(),
+                fields: [
+                    ("message".into(), "close".into()),
+                    ("time.busy".into(), "206µs".into()),
+                    ("time.idle".into(), "246µs".into()),
+                ]
+                .into(),
+                target: "ghciwatch::ghci::error_log".into(),
+                span: None,
+                spans: vec![
+                    Span::new("on_action"),
+                    Span::new("reload"),
+                    Span {
+                        name: "error_log_write".into(),
+                        rest: [(
+                            "compilation_summary".into(),
+                            "Some(CompilationSummary { result: Ok, modules_loaded: 4 })".into()
+                        )]
+                        .into(),
+                    }
+                ]
+            })
+            .unwrap());
+
+        // Span exists, but it's not the leaf span.
+        assert!(BaseMatcher::span_close()
+            .in_leaf_span("error_log_write")
+            .matches(&Event {
+                timestamp: "2023-09-12T18:06:04.677942Z".into(),
+                level: Level::DEBUG,
+                message: "close".into(),
+                fields: [
+                    ("message".into(), "close".into()),
+                    ("time.busy".into(), "206µs".into()),
+                    ("time.idle".into(), "246µs".into()),
+                ]
+                .into(),
+                target: "ghciwatch::ghci::error_log".into(),
+                span: None,
+                spans: vec![
+                    Span::new("on_action"),
+                    Span {
+                        name: "error_log_write".into(),
+                        rest: [(
+                            "compilation_summary".into(),
+                            "Some(CompilationSummary { result: Ok, modules_loaded: 4 })".into()
+                        )]
+                        .into(),
+                    },
+                    Span::new("reload"),
+                ]
             })
             .unwrap());
     }

--- a/test-harness/src/matcher/base_matcher.rs
+++ b/test-harness/src/matcher/base_matcher.rs
@@ -48,13 +48,13 @@ impl BaseMatcher {
     /// Utility for constructing a matcher that waits until the inner `ghci` finishes compilation
     /// successfully.
     pub fn compilation_succeeded() -> Self {
-        Self::message("^Compilation succeeded$").in_leaf_span("reload")
+        Self::message("^Compilation succeeded$").in_spans(["reload"])
     }
 
     /// Utility for constructing a matcher that waits until the inner `ghci` finishes compilation
     /// unsuccessfully.
     pub fn compilation_failed() -> Self {
-        Self::message("^Compilation failed$").in_leaf_span("reload")
+        Self::message("^Compilation failed$").in_spans(["reload"])
     }
 
     /// Utility for constructing a matcher that waits until the inner `ghci` compiles the given
@@ -63,7 +63,7 @@ impl BaseMatcher {
     /// The module is given by name (`My.Module`), not path (`src/My/Module.hs`).
     pub fn module_compiling(module: &str) -> Self {
         Self::message("^Compiling$")
-            .in_leaf_span("reload")
+            .in_spans(["reload"])
             .with_field("module", &regex::escape(module))
     }
 

--- a/tests/all_good.rs
+++ b/tests/all_good.rs
@@ -1,0 +1,45 @@
+use test_harness::test;
+use test_harness::BaseMatcher;
+use test_harness::GhciWatchBuilder;
+use test_harness::Matcher;
+
+/// Test that `ghciwatch` can detect when compilation fails.
+///
+/// Regression test for DUX-1649.
+#[test]
+async fn can_detect_compilation_failure() {
+    let mut session = GhciWatchBuilder::new("tests/data/simple")
+        .start()
+        .await
+        .expect("ghciwatch starts");
+    let module_path = session.path("src/MyModule.hs");
+
+    session.wait_until_ready().await.expect("ghciwatch loads");
+
+    session
+        .fs()
+        .replace(&module_path, "example :: String", "example :: ()")
+        .await
+        .unwrap();
+
+    session
+        .wait_for_log(BaseMatcher::compilation_failed())
+        .await
+        .unwrap();
+
+    session
+        .wait_for_log(BaseMatcher::reload_completes().but_not(BaseMatcher::message("All good!")))
+        .await
+        .unwrap();
+
+    session
+        .fs()
+        .replace(&module_path, "example :: ()", "example :: String")
+        .await
+        .unwrap();
+
+    session
+        .wait_for_log(BaseMatcher::message("All good!"))
+        .await
+        .unwrap();
+}

--- a/tests/error_log.rs
+++ b/tests/error_log.rs
@@ -69,7 +69,7 @@ async fn can_write_error_log_compilation_errors() {
         .expect("ghciwatch loads new modules");
 
     session
-        .wait_for_log(BaseMatcher::span_close().in_span("error_log_write"))
+        .wait_for_log(BaseMatcher::span_close().in_leaf_span("error_log_write"))
         .await
         .expect("ghciwatch writes ghcid.txt");
 
@@ -118,7 +118,7 @@ async fn can_write_error_log_compilation_errors() {
         .expect("ghciwatch reloads on changes");
 
     session
-        .wait_for_log(BaseMatcher::span_close().in_span("error_log_write"))
+        .wait_for_log(BaseMatcher::span_close().in_leaf_span("error_log_write"))
         .await
         .expect("ghciwatch writes ghcid.txt");
 

--- a/tests/failed_modules.rs
+++ b/tests/failed_modules.rs
@@ -1,5 +1,3 @@
-mod all_good;
-
 use test_harness::test;
 use test_harness::Fs;
 use test_harness::GhciWatchBuilder;

--- a/tests/failed_modules.rs
+++ b/tests/failed_modules.rs
@@ -1,3 +1,5 @@
+mod all_good;
+
 use test_harness::test;
 use test_harness::Fs;
 use test_harness::GhciWatchBuilder;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -25,7 +25,7 @@ async fn can_run_test_suite_on_reload() {
         .expect("Can touch file");
 
     session
-        .wait_for_log(BaseMatcher::span_close().in_span("error_log_write"))
+        .wait_for_log(BaseMatcher::span_close().in_leaf_span("error_log_write"))
         .await
         .expect("ghciwatch writes ghcid.txt");
     session


### PR DESCRIPTION
Turned out I wasn't ever setting the "compilation failed" variable where I expected it.

Also I had a bug with the `BaseMatcher`, so I fixed it to be stricter about spans.