### PR TITLE
Make the compilation failed message visible

### DIFF
--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -459,7 +459,7 @@ impl Ghci {
                 .await?;
 
             if let Some(CompilationResult::Err) = log.result() {
-                tracing::debug!("Compilation failed, skipping running tests");
+                tracing::error!("Compilation failed in {:.2?}", start_instant.elapsed());
             } else {
                 tracing::info!(
                     "{} Finished reloading in {:.2?}",

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -40,12 +40,23 @@ impl Display for LifecycleEvent {
 }
 
 impl LifecycleEvent {
-    fn event_name(&self) -> &'static str {
+    /// Get the event name, like `test` or `reload`.
+    pub fn event_name(&self) -> &'static str {
         match self {
             LifecycleEvent::Test => "test",
             LifecycleEvent::Startup(_) => "startup",
             LifecycleEvent::Reload(_) => "reload",
             LifecycleEvent::Restart(_) => "restart",
+        }
+    }
+
+    /// Get the noun form of the event name, like `testing` or `reloading`.
+    pub fn event_noun(&self) -> &'static str {
+        match self {
+            LifecycleEvent::Test => "testing",
+            LifecycleEvent::Startup(_) => "starting up",
+            LifecycleEvent::Reload(_) => "reloading",
+            LifecycleEvent::Restart(_) => "restarting",
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,12 +29,14 @@ mod incremental_reader;
 mod maybe_async_command;
 mod normal_path;
 mod shutdown;
+mod string_case;
 mod tracing;
 mod watcher;
 
 pub(crate) use cwd::current_dir;
 pub(crate) use cwd::current_dir_utf8;
 pub(crate) use format_bulleted_list::format_bulleted_list;
+pub(crate) use string_case::StringCase;
 
 pub use ghci::manager::run_ghci;
 pub use ghci::Ghci;

--- a/src/string_case.rs
+++ b/src/string_case.rs
@@ -1,0 +1,43 @@
+/// Extension for changing the case of strings.
+pub trait StringCase {
+    /// Capitalize the first character of the string, if it's an ASCII codepoint.
+    fn first_char_to_ascii_uppercase(&self) -> String;
+}
+
+impl<S> StringCase for S
+where
+    S: AsRef<str>,
+{
+    fn first_char_to_ascii_uppercase(&self) -> String {
+        let s = self.as_ref();
+        let mut ret = String::with_capacity(s.len());
+
+        let mut chars = s.chars();
+
+        match chars.next() {
+            Some(c) => {
+                ret.push(c.to_ascii_uppercase());
+            }
+            None => {
+                return ret;
+            }
+        }
+
+        ret.extend(chars);
+
+        ret
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_sentence_case() {
+        assert_eq!("dog".first_char_to_ascii_uppercase(), "Dog");
+        assert_eq!("puppy dog".first_char_to_ascii_uppercase(), "Puppy dog");
+        assert_eq!("puppy-dog".first_char_to_ascii_uppercase(), "Puppy-dog");
+        assert_eq!("Puppy-dog".first_char_to_ascii_uppercase(), "Puppy-dog");
+    }
+}

--- a/test-harness/src/matcher/base_matcher.rs
+++ b/test-harness/src/matcher/base_matcher.rs
@@ -143,7 +143,7 @@ impl BaseMatcher {
 
     /// Match when `ghciwatch` completes its initial load.
     pub fn ghci_started() -> Self {
-        Self::message(r"^ghci started in \d+\.\d+m?s$")
+        Self::message(r"(Starting up failed|Finished starting up) in \d+\.\d+m?s$")
     }
 
     /// Match when the filesystem worker starts.


### PR DESCRIPTION
Make the "compilation failed" message error-level rather than debug-level. The `ghci` error output does generally show when compilation fails, but without a visible prompt it's not super clear when exactly compilation finished. This is a follow-up to #167 + #170, which added an "All good!" message.