### PR TITLE
Let `Shutdown{Manager,Handle}::spawn` take `&str`

### DIFF
--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -252,7 +252,7 @@ impl Ghci {
         };
 
         shutdown
-            .spawn("stderr".to_owned(), |shutdown| {
+            .spawn("stderr", |shutdown| {
                 GhciStderr {
                     shutdown,
                     reader: BufReader::new(stderr).lines(),
@@ -267,7 +267,7 @@ impl Ghci {
         let (restart_sender, restart_receiver) = mpsc::channel(1);
 
         shutdown
-            .spawn("ghci_process".to_owned(), |shutdown| {
+            .spawn("ghci_process", |shutdown| {
                 GhciProcess {
                     shutdown,
                     restart_receiver,

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,12 +30,12 @@ async fn main() -> miette::Result<()> {
 
     let mut manager = ShutdownManager::with_timeout(Duration::from_secs(1));
     manager
-        .spawn("run_ghci".to_owned(), |handle| {
+        .spawn("run_ghci", |handle| {
             run_ghci(handle, ghci_opts, ghci_receiver)
         })
         .await;
     manager
-        .spawn("run_watcher".to_owned(), move |handle| {
+        .spawn("run_watcher", move |handle| {
             run_watcher(handle, ghci_sender, watcher_opts)
         })
         .await;


### PR DESCRIPTION
Their `spawn` methods are usually invoked with string literals (`&str`), so it's nicer to do the conversion to an owned string internally.

I used `impl Into<String>` instead of `&str` to ensure we don't re-allocate if we already have a `String`.