### PR TITLE
Release version 0.5.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "ghciwatch"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "aho-corasick",
  "async-dup",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ publish = false # Don't do `cargo publish`.
 # Define the root package: https://doc.rust-lang.org/cargo/reference/workspaces.html#root-package
 [package]
 name = "ghciwatch"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2021"
 authors = [
     "Rebecca Turner <rebeccat@mercury.com>"


### PR DESCRIPTION
Update version to 0.5.6 with [cargo-release](https://github.com/crate-ci/cargo-release).
Merge this PR to build and publish a new release.