### PR TITLE
Write `--errors` log before running shell hooks

### DIFF
--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -750,7 +750,7 @@ impl Ghci {
         Ok(())
     }
 
-    #[instrument(skip(self), level = "trace")]
+    #[instrument(skip_all, fields(%event), level = "trace")]
     async fn run_hooks(
         &mut self,
         event: LifecycleEvent,

--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -489,10 +489,12 @@ impl Ghci {
         let new = Self::new(self.shutdown.clone(), self.opts.clone()).await?;
         let _ = std::mem::replace(self, new);
         self.initialize(&mut log).await?;
+
+        // Allow hooks to consume the error log by updating it before running the hooks.
+        self.write_error_log(&log).await?;
         self.run_hooks(LifecycleEvent::Restart(hooks::When::After), &mut log)
             .await?;
 
-        self.write_error_log(&log).await?;
         Ok(())
     }
 
@@ -725,6 +727,9 @@ impl Ghci {
         log: &mut CompilationLog,
         event: LifecycleEvent,
     ) -> miette::Result<()> {
+        // Allow hooks to consume the error log by updating it before running the hooks.
+        self.write_error_log(log).await?;
+
         self.run_hooks(event, log).await?;
 
         if let Some(CompilationResult::Err) = log.result() {
@@ -746,7 +751,6 @@ impl Ghci {
             self.test(log).await?;
         }
 
-        self.write_error_log(log).await?;
         Ok(())
     }
 

--- a/test-harness/src/lib.rs
+++ b/test-harness/src/lib.rs
@@ -15,6 +15,7 @@ pub use matcher::IntoMatcher;
 pub use matcher::Matcher;
 pub use matcher::OptionMatcher;
 pub use matcher::OrMatcher;
+pub use matcher::SpanMatcher;
 
 mod fs;
 pub use fs::Fs;

--- a/test-harness/src/matcher/field_matcher.rs
+++ b/test-harness/src/matcher/field_matcher.rs
@@ -1,0 +1,87 @@
+use std::collections::HashMap;
+use std::fmt::Display;
+
+use itertools::Itertools;
+use regex::Regex;
+use serde_json::Value;
+
+/// A matcher for fields and values in key-value maps.
+///
+/// Used for span and event fields.
+#[derive(Clone, Default)]
+pub struct FieldMatcher {
+    fields: HashMap<String, Regex>,
+}
+
+impl FieldMatcher {
+    /// True if this matcher contains any fields.
+    pub fn is_empty(&self) -> bool {
+        self.fields.is_empty()
+    }
+
+    /// Require that matching objects contain a field with the given name and a value matching the
+    /// given regex.
+    ///
+    /// ### Panics
+    ///
+    /// If the `value_regex` fails to compile.
+    pub fn with_field(mut self, name: &str, value_regex: &str) -> Self {
+        self.fields.insert(
+            name.to_owned(),
+            Regex::new(value_regex).expect("Value regex failed to compile"),
+        );
+        self
+    }
+
+    /// True if the given field access function yields fields which validate this matcher.
+    pub fn matches<'a>(&'a self, get_field: impl Fn(&'a str) -> Option<&Value>) -> bool {
+        for (name, value_regex) in &self.fields {
+            let value = get_field(name);
+            match value {
+                None => {
+                    // We expected the field to be present.
+                    return false;
+                }
+                Some(value) => {
+                    match value {
+                        Value::Null
+                        | Value::Bool(_)
+                        | Value::Number(_)
+                        | Value::Array(_)
+                        | Value::Object(_) => {
+                            // We expected the value to be a string.
+                            return false;
+                        }
+                        Value::String(value) => {
+                            if !value_regex.is_match(value) {
+                                // We expected the regex to match.
+                                return false;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        true
+    }
+}
+
+impl Display for FieldMatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.fields.is_empty() {
+            write!(f, "any fields")?;
+        } else {
+            write!(
+                f,
+                "with fields {}",
+                self.fields
+                    .iter()
+                    .map(|(k, v)| format!("{k}={v:?}"))
+                    .join(", ")
+            )?;
+        }
+
+        Ok(())
+    }
+}

--- a/test-harness/src/matcher/mod.rs
+++ b/test-harness/src/matcher/mod.rs
@@ -2,6 +2,12 @@ use std::fmt::Display;
 
 use crate::Event;
 
+mod span_matcher;
+pub use span_matcher::SpanMatcher;
+
+mod field_matcher;
+pub(crate) use field_matcher::FieldMatcher;
+
 mod into_matcher;
 pub use into_matcher::IntoMatcher;
 

--- a/test-harness/src/matcher/span_matcher.rs
+++ b/test-harness/src/matcher/span_matcher.rs
@@ -1,0 +1,64 @@
+use std::fmt::Display;
+
+use crate::tracing_json::Span;
+
+use super::FieldMatcher;
+
+/// A [`Span`] matcher.
+#[derive(Clone)]
+pub struct SpanMatcher {
+    name: String,
+    fields: FieldMatcher,
+}
+
+impl SpanMatcher {
+    /// Construct a query for spans with the given name.
+    pub fn new(name: impl AsRef<str>) -> Self {
+        Self {
+            name: name.as_ref().to_owned(),
+            fields: Default::default(),
+        }
+    }
+
+    /// Require that matching spans contain a field with the given name and a value matching the
+    /// given regex.
+    ///
+    /// ### Panics
+    ///
+    /// If the `value_regex` fails to compile.
+    pub fn with_field(mut self, name: &str, value_regex: &str) -> Self {
+        self.fields = self.fields.with_field(name, value_regex);
+        self
+    }
+
+    /// Determine if this matcher matches the given [`Span`].
+    pub fn matches(&self, span: &Span) -> bool {
+        if span.name != self.name {
+            return false;
+        }
+
+        if !self.fields.matches(|name| span.fields.get(name)) {
+            return false;
+        }
+
+        true
+    }
+}
+
+impl From<&str> for SpanMatcher {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+impl Display for SpanMatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.name)?;
+
+        if !self.fields.is_empty() {
+            write!(f, " {}", self.fields)?;
+        }
+
+        Ok(())
+    }
+}

--- a/test-harness/src/matcher/span_matcher.rs
+++ b/test-harness/src/matcher/span_matcher.rs
@@ -33,15 +33,7 @@ impl SpanMatcher {
 
     /// Determine if this matcher matches the given [`Span`].
     pub fn matches(&self, span: &Span) -> bool {
-        if span.name != self.name {
-            return false;
-        }
-
-        if !self.fields.matches(|name| span.fields.get(name)) {
-            return false;
-        }
-
-        true
+        span.name == self.name && self.fields.matches(|name| span.fields.get(name))
     }
 }
 

--- a/test-harness/src/tracing_json.rs
+++ b/test-harness/src/tracing_json.rs
@@ -80,7 +80,7 @@ impl TryFrom<JsonEvent> for Event {
                 .into_diagnostic()
                 .wrap_err_with(|| format!("Failed to parse tracing level: {}", event.level))?,
             message: event.fields.message,
-            fields: event.fields.rest,
+            fields: event.fields.fields,
             target: event.target,
             span: event.span,
             spans: event.spans,
@@ -106,7 +106,7 @@ pub struct Span {
     pub name: String,
     /// The span's fields; extra data attached to this span.
     #[serde(flatten)]
-    pub rest: HashMap<String, serde_json::Value>,
+    pub fields: HashMap<String, serde_json::Value>,
 }
 
 impl Span {
@@ -114,14 +114,14 @@ impl Span {
     pub fn new(name: impl Display) -> Self {
         Self {
             name: name.to_string(),
-            rest: Default::default(),
+            fields: Default::default(),
         }
     }
 }
 
 impl Display for Span {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}{}", self.name, display_map(&self.rest))
+        write!(f, "{}{}", self.name, display_map(&self.fields))
     }
 }
 
@@ -129,7 +129,7 @@ impl Display for Span {
 struct Fields {
     message: String,
     #[serde(flatten)]
-    rest: HashMap<String, serde_json::Value>,
+    fields: HashMap<String, serde_json::Value>,
 }
 
 fn display_map(hashmap: &HashMap<String, serde_json::Value>) -> String {


### PR DESCRIPTION
This lets users observe error log output in lifecycle hooks. Useful for some editor integrations, e.g.:

```
vim --servername $VIM_SERVERNAME --remote-send "<C-W>:cgetfile ghcid.txt<CR>"
```


Also adds a couple features to the test harness:
- Extra tracing filters (`--tracing-filter`) can be added in tests
- Span fields can now be matched as well as names