### PR TITLE
Clear the screen on reload with `--clear`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,6 +249,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
+name = "clearscreen"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f3f22f1a586604e62efd23f78218f3ccdecf7a33c4500db2d37d85a24fe994"
+dependencies = [
+ "nix",
+ "terminfo",
+ "thiserror",
+ "which",
+ "winapi",
+]
+
+[[package]]
 name = "clonable-command"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +342,26 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
 
 [[package]]
 name = "dissimilar"
@@ -431,6 +464,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +553,7 @@ dependencies = [
  "backoff",
  "camino",
  "clap",
+ "clearscreen",
  "command-group",
  "enum-iterator",
  "expect-test",
@@ -585,6 +625,15 @@ name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "humantime"
@@ -719,6 +768,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
+name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
 name = "line-span"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,6 +860,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +895,16 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -971,6 +1047,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1173,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -1215,6 +1340,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,6 +1498,19 @@ checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
  "rustix 0.38.28",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666cd3a6681775d22b200409aad3b089c5b99fb11ecdd8a204d9d62f8148498f"
+dependencies = [
+ "dirs",
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -1716,6 +1860,18 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.28",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ async-dup = "1.2.4"
 backoff = { version = "0.4.0", default-features = false }
 camino = "1.1.4"
 clap = { version = "4.3.2", features = ["derive", "wrap_help", "env", "string"] }
+clearscreen = "2.0.1"
 command-group = { version = "2.1.0", features = ["tokio", "with-tokio"] }
 enum-iterator = "1.4.1"
 humantime = "2.1.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,6 +38,10 @@ pub struct Opts {
     #[arg(long, alias = "allow-eval")]
     pub enable_eval: bool,
 
+    /// Clear the screen before reloads and restarts.
+    #[arg(long)]
+    pub clear: bool,
+
     /// Lifecycle hooks and commands to run at various points.
     #[command(flatten)]
     pub hooks: crate::hooks::HookOpts,

--- a/tests/clear.rs
+++ b/tests/clear.rs
@@ -1,0 +1,65 @@
+use indoc::indoc;
+
+use test_harness::test;
+use test_harness::BaseMatcher;
+use test_harness::GhciWatchBuilder;
+
+/// Test that `ghciwatch` clears the screen on reloads and restarts when `--clear` is used.
+#[test]
+async fn clears_on_reload_and_restart() {
+    let mut session = GhciWatchBuilder::new("tests/data/simple")
+        .with_arg("--clear")
+        .with_tracing_filter("ghciwatch::ghci[clear]=trace")
+        .start()
+        .await
+        .expect("ghciwatch starts");
+    session
+        .wait_until_ready()
+        .await
+        .expect("ghciwatch loads ghci");
+
+    session
+        .fs()
+        .append(
+            session.path("src/MyLib.hs"),
+            indoc!(
+                "
+
+                hello = 1 :: Integer
+
+                "
+            ),
+        )
+        .await
+        .unwrap();
+
+    session.wait_for_log("Clearing the screen").await.unwrap();
+    session
+        .wait_until_reload()
+        .await
+        .expect("ghciwatch reloads on changes");
+    session
+        .wait_for_log(BaseMatcher::reload_completes())
+        .await
+        .unwrap();
+
+    {
+        // Rename the module and fix the module name to match the new path.
+        let module_path = session.path("src/MyModule.hs");
+        let new_path = session.path("src/MyCoolModule.hs");
+        session.fs_mut().disable_load_bearing_sleep();
+        session.fs().rename(&module_path, &new_path).await.unwrap();
+        session
+            .fs()
+            .replace(&new_path, "module MyModule", "module MyCoolModule")
+            .await
+            .unwrap();
+        session.fs_mut().reset_load_bearing_sleep();
+    }
+
+    session.wait_for_log("Clearing the screen").await.unwrap();
+    session
+        .wait_until_restart()
+        .await
+        .expect("ghciwatch restarts ghci");
+}

--- a/tests/restart.rs
+++ b/tests/restart.rs
@@ -22,9 +22,9 @@ async fn can_restart_after_module_move() {
             &module_path,
             indoc!(
                 "module My.Module (myIdent) where
-            myIdent :: ()
-            myIdent = ()
-            "
+                myIdent :: ()
+                myIdent = ()
+                "
             ),
         )
         .await


### PR DESCRIPTION
It's possible to hack around this with lifecycle hooks:

```shell
ghciwatch \
  --before-startup-shell 'sh -c "clear >/dev/tty"' \
  --before-reload-shell 'sh -c "clear >/dev/tty"' \
  --before-restart-shell 'sh -c "clear >/dev/tty"'
```

But it's nice to have a baked option for it.