### PR TITLE
Support multiple spans in `BaseMatcher::in_leaf_span`

### DIFF
--- a/test-harness/src/tracing_json.rs
+++ b/test-harness/src/tracing_json.rs
@@ -30,7 +30,7 @@ pub struct Event {
 
 impl Event {
     /// Get an iterator over this event's spans, from the outside in (root to leaf).
-    pub fn spans(&self) -> impl Iterator<Item = &Span> {
+    pub fn spans(&self) -> impl Iterator<Item = &Span> + DoubleEndedIterator {
         self.spans.iter().chain({
             // The `new`, `exit`, and `close` span lifecycle events aren't emitted from inside the
             // relevant span, so the span isn't listed in `spans`. Instead, the relevant span is in

--- a/tests/error_log.rs
+++ b/tests/error_log.rs
@@ -69,7 +69,7 @@ async fn can_write_error_log_compilation_errors() {
         .expect("ghciwatch loads new modules");
 
     session
-        .wait_for_log(BaseMatcher::span_close().in_leaf_span("error_log_write"))
+        .wait_for_log(BaseMatcher::span_close().in_leaf_spans(["error_log_write"]))
         .await
         .expect("ghciwatch writes ghcid.txt");
 
@@ -118,7 +118,7 @@ async fn can_write_error_log_compilation_errors() {
         .expect("ghciwatch reloads on changes");
 
     session
-        .wait_for_log(BaseMatcher::span_close().in_leaf_span("error_log_write"))
+        .wait_for_log(BaseMatcher::span_close().in_leaf_spans(["error_log_write"]))
         .await
         .expect("ghciwatch writes ghcid.txt");
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -25,7 +25,7 @@ async fn can_run_test_suite_on_reload() {
         .expect("Can touch file");
 
     session
-        .wait_for_log(BaseMatcher::span_close().in_leaf_span("error_log_write"))
+        .wait_for_log(BaseMatcher::span_close().in_leaf_spans(["error_log_write"]))
         .await
         .expect("ghciwatch writes ghcid.txt");
     session


### PR DESCRIPTION
This makes it easier to identify the correct span (e.g. `in_spans(["run_ghci", "initialize"])` would match an event with spans `["run_ghci", "stdout", "initialize"]`, but `in_leaf_spans` would not).