### PR TITLE
Fix a flaky error log test

### DIFF
--- a/src/ghci/error_log.rs
+++ b/src/ghci/error_log.rs
@@ -53,6 +53,7 @@ impl ErrorLog {
         }
 
         for diagnostic in &log.diagnostics {
+            tracing::debug!(%diagnostic, "Writing diagnostic");
             writer
                 .write_all(diagnostic.to_string().as_bytes())
                 .await

--- a/tests/error_log.rs
+++ b/tests/error_log.rs
@@ -73,6 +73,11 @@ async fn can_write_error_log_compilation_errors() {
         .await
         .expect("ghciwatch writes ghcid.txt");
 
+    session
+        .wait_for_log(BaseMatcher::reload_completes())
+        .await
+        .expect("ghciwatch finishes reloading");
+
     let error_contents = session
         .fs()
         .read(&error_path)


### PR DESCRIPTION
```
// TODO: Could this cause problems where we get an event and a final stderr line is only
// processed after we write the error log?
```

Turns out the answer is "yes"!