### PR TITLE
Generate documentation for the rest of the workspace

### DIFF
--- a/nix/packages/ghciwatch.nix
+++ b/nix/packages/ghciwatch.nix
@@ -106,7 +106,7 @@
       });
     ghciwatch-doc = craneLib.cargoDoc (commonArgs
       // {
-        cargoDocExtraArgs = "--document-private-items";
+        cargoDocExtraArgs = "--document-private-items --no-deps --workspace";
         RUSTDOCFLAGS = "-D warnings";
       });
     ghciwatch-fmt = craneLib.cargoFmt commonArgs;

--- a/test-harness/src/ghciwatch.rs
+++ b/test-harness/src/ghciwatch.rs
@@ -245,8 +245,8 @@ pub struct GhciWatch {
     startup_timeout: Duration,
     /// Filesystem helpers.
     fs: Fs,
-    /// Data for this particular `ghciwatch` run. This changes when [`GhciWatch::restart`] is
-    /// called.
+    /// Data for this particular `ghciwatch` run. This changes when
+    /// [`GhciWatch::restart_ghciwatch`] is called.
     ghciwatch: Session,
 }
 

--- a/test-harness/src/internal.rs
+++ b/test-harness/src/internal.rs
@@ -35,7 +35,7 @@ thread_local! {
 ///
 /// Then we run the user test code. If it errors, we save the logs to `CARGO_TARGET_TMPDIR`.
 ///
-/// Finally, we wait for the process set by [`set_ghciwatch_process`] to exit and clean up the
+/// Finally, we wait for the process set by `set_ghciwatch_process` to exit and clean up the
 /// temporary directory `GhciWatch` created.
 pub async fn wrap_test(
     test: impl Future<Output = ()> + Send + 'static,

--- a/test-harness/src/lib.rs
+++ b/test-harness/src/lib.rs
@@ -6,6 +6,7 @@ pub use serde_json::Value as JsonValue;
 
 mod tracing_json;
 pub use tracing_json::Event;
+pub use tracing_json::Span;
 
 mod tracing_reader;
 


### PR DESCRIPTION
This checks documentation for the `test-harness` crate in CI.