### PR TITLE
Run after-restart hooks before eval commands and test suites

### DIFF
--- a/docs/lifecycle-hooks.md
+++ b/docs/lifecycle-hooks.md
@@ -142,11 +142,7 @@ are deleted or moved, or when any files specified by
 Hooks: [`--after-restart-shell`](cli.md#--after-restart-shell),
 [`--after-restart-ghci`](cli.md#--after-restart-ghci).
 
-When: After the GHCi session has been restarted, the [after
-startup](#after-startup) hooks have run, and after [eval
+When: After the GHCi session has been restarted, the [error
+log](cli.md#--error-file) has been written, and the [after
+startup](#after-startup) hooks have run, but before [eval
 commands](comment-evaluation.md) and [test suites](#test) are executed.
-
-In the future, these hooks may run before eval commands and test suites are
-executed (see [#242][242]).
-
-[242]: https://github.com/MercuryTechnologies/ghciwatch/issues/242

--- a/src/ghci/manager.rs
+++ b/src/ghci/manager.rs
@@ -13,6 +13,8 @@ use tracing::instrument;
 
 use crate::event_filter::FileEvent;
 use crate::ghci::CompilationLog;
+use crate::hooks;
+use crate::hooks::LifecycleEvent;
 use crate::shutdown::ShutdownHandle;
 
 use super::Ghci;
@@ -67,7 +69,7 @@ pub async fn run_ghci(
         _ = handle.on_shutdown_requested() => {
             ghci.stop().await.wrap_err("Failed to quit ghci")?;
         }
-        startup_result = ghci.initialize(&mut log) => {
+        startup_result = ghci.initialize(&mut log, [LifecycleEvent::Startup(hooks::When::After)]) => {
             startup_result?;
         }
     }


### PR DESCRIPTION
Fixes an inconsistency between after-startup and after-restart hooks