### PR TITLE
Add treefmt

### DIFF
--- a/nix/packages/ghciwatch.nix
+++ b/nix/packages/ghciwatch.nix
@@ -14,6 +14,8 @@
   rust-analyzer,
   mdbook,
   installShellFiles,
+  treefmt,
+  alejandra,
   # Versions of GHC to include in the environment for integration tests.
   # These should be attributes of `haskell.compiler`.
   ghcVersions ? null,
@@ -258,6 +260,8 @@
     packages = [
       rust-analyzer
       mdbook
+      treefmt
+      alejandra
     ];
   };
 in

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -1,0 +1,9 @@
+[formatter.nix]
+# TODO: Use nixfmt-rfc-style
+command = "alejandra"
+includes = ["*.nix"]
+
+[formatter.rust]
+command = "rustfmt"
+options = ["--edition", "2021"]
+includes = ["*.rs"]


### PR DESCRIPTION
Adds a `treefmt.toml` for formatting Rust and Nix code

Next: CI checks for treefmt (but this requires refactoring the flake checks so it's a bigger diff)