### PR TITLE
Release version 0.5.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "ghciwatch"
-version = "0.5.12"
+version = "0.5.13"
 dependencies = [
  "aho-corasick",
  "ansi-to-tui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ publish = false # Don't do `cargo publish`.
 # Define the root package: https://doc.rust-lang.org/cargo/reference/workspaces.html#root-package
 [package]
 name = "ghciwatch"
-version = "0.5.12"
+version = "0.5.13"
 edition = "2021"
 authors = [
     "Rebecca Turner <rebeccat@mercury.com>"


### PR DESCRIPTION
Update version to 0.5.13 with [cargo-release](https://github.com/crate-ci/cargo-release).
Merge this PR to build and publish a new release.