### PR TITLE
Fix publishing the user manual on GitHub Pages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -213,6 +213,9 @@ jobs:
     needs:
       - build
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Download artifacts
         # This downloads the uploaded artifacts to the current directory; the
         # path format for downloaded artifacts is `{name}/{basename}`, where


### PR DESCRIPTION
What if 👉👈 I had to cut like three releases 😜 to get the user manual published 🤯 because GitHub Actions doesn't have any tools to let you test your actions before you run them 😳 and we were both girls!??