### PR TITLE
Adding coverage reporting for tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ To run tests, you'll need [Nix/Lix][lix] installed. Run `nix
 develop` to enter a [development shell][dev-env] with all the dependencies
 available and then use `cargo nextest run` to run the tests (including the
 integration tests) with [`cargo-nextest`][nextest]. (`cargo test` will work,
-too, but slower.)
+too, but slower.) You can run the tests with coverage output with `cargo llvm-cov nextest`. 
 
 [rustup]: https://rustup.rs/
 [lix]: https://lix.systems/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+
+[[package]]
 name = "async-dup"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,8 +214,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
+ "regex-automata 0.4.6",
  "serde",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -222,6 +235,47 @@ name = "camino"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+
+[[package]]
+name = "cargo-config2"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83ce0be8bd1479e5de6202def660e6c7e27e4e0599bffa4fed05bd380ec2ede"
+dependencies = [
+ "home",
+ "serde",
+ "serde_derive",
+ "toml_edit",
+]
+
+[[package]]
+name = "cargo-llvm-cov"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "137c054c19f1134aabe426018c3d8718ff5cfe679ba895f3f0a869eccf8b380b"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo-config2",
+ "duct",
+ "fs-err",
+ "glob",
+ "home",
+ "is_executable",
+ "lcov2cobertura",
+ "lexopt",
+ "opener",
+ "regex",
+ "rustc-demangle",
+ "ruzstd",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "shell-escape",
+ "tar",
+ "termcolor",
+ "walkdir",
+]
 
 [[package]]
 name = "cassowary"
@@ -420,6 +474,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +517,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "440d59c0c6d96354061909b4769b2ca03868dbaee203e7b779d9021ebbde3058"
 
 [[package]]
+name = "duct"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ab5718d1224b63252cd0c6f74f6480f9ffeb117438a2e0f5cf6d9a4798929c"
+dependencies = [
+ "libc",
+ "once_cell",
+ "os_pipe",
+ "shared_child",
+]
+
+[[package]]
 name = "either"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +553,12 @@ dependencies = [
  "quote",
  "syn 2.0.60",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -550,6 +633,15 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "fs_extra"
@@ -635,6 +727,7 @@ dependencies = [
  "async-dup",
  "backoff",
  "camino",
+ "cargo-llvm-cov",
  "clap",
  "clearscreen",
  "command-group",
@@ -672,7 +765,7 @@ dependencies = [
  "tracing-subscriber",
  "tracing-test",
  "unindent",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -680,6 +773,12 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
@@ -757,6 +856,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "indoc"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,6 +935,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
+name = "is_executable"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa9acdc6d67b75e626ad644734e8bc6df893d9cd2a834129065d3dd6158ea9c8"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,6 +992,24 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lcov2cobertura"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dbf995693421c277b440a71144e33246d8a76808418f7430329e44b2e95c03"
+dependencies = [
+ "anyhow",
+ "quick-xml",
+ "regex",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "lexopt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baff4b617f7df3d896f97fe922b64817f6cd9a756bb81d40f8883f2f66dcb401"
 
 [[package]]
 name = "libc"
@@ -1030,6 +1166,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "normpath"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5831952a9476f2fed74b77d74182fa5ddc4d21c72ec45a333b250e3ed0272804"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "notify"
 version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1247,27 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "opener"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8df34be653210fbe9ffaff41d3b92721c56ce82dfee58ee684f9afb5e3a90c0"
+dependencies = [
+ "bstr",
+ "normpath",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57119c3b893986491ec9aa85056780d3a0f3cf4da7cc09dd3650dbd6c6738fb9"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "overload"
@@ -1259,6 +1425,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1433,6 +1608,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
 
 [[package]]
+name = "ruzstd"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5174a470eeb535a721ae9fdd6e291c2411a906b96592182d05217591d5c5cf7b"
+dependencies = [
+ "byteorder",
+ "derive_more",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1491,6 +1676,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,6 +1692,22 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shared_child"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0d94659ad3c2137fef23ae75b03d5241d633f8acded53d672decfa0e6e0caef"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "shell-escape"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
 name = "shell-words"
@@ -1698,6 +1908,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,6 +1928,15 @@ dependencies = [
  "fastrand",
  "rustix 0.38.34",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1927,6 +2157,28 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.6.8",
 ]
 
 [[package]]
@@ -2326,6 +2578,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "xattr"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+dependencies = [
+ "libc",
+ "linux-raw-sys 0.4.13",
+ "rustix 0.38.34",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ test-harness = { path = "test-harness" }
 expect-test = "1.4.0"
 pretty_assertions = "1.2.1"
 tracing-test = { version = "0.2", features = ["no-env-filter"] }
+cargo-llvm-cov = "0.6.9"
 
 [lib]
 path = "src/lib.rs"

--- a/flake.nix
+++ b/flake.nix
@@ -106,8 +106,6 @@
           cargo = pkgs.rustToolchain.overrideAttrs {
             pname = "cargo";
           };
-          inherit pkgs;
-          inherit localPackages;
         }
         // (pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
           # ghciwatch cross-compiled to aarch64-linux.

--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,7 @@
                     "x86_64-unknown-linux-musl"
                     "aarch64-unknown-linux-musl"
                   ];
-                  extensions = [ "llvm-tools-preview" ];
+                extensions = ["llvm-tools-preview"];
               };
 
               craneLib = (crane.mkLib final).overrideToolchain final.rustToolchain;
@@ -106,6 +106,8 @@
           cargo = pkgs.rustToolchain.overrideAttrs {
             pname = "cargo";
           };
+          inherit pkgs;
+          inherit localPackages;
         }
         // (pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
           # ghciwatch cross-compiled to aarch64-linux.

--- a/flake.nix
+++ b/flake.nix
@@ -62,6 +62,7 @@
                     "x86_64-unknown-linux-musl"
                     "aarch64-unknown-linux-musl"
                   ];
+                  extensions = [ "llvm-tools-preview" ];
               };
 
               craneLib = (crane.mkLib final).overrideToolchain final.rustToolchain;

--- a/nix/packages/cargo-llvm-cov.nix
+++ b/nix/packages/cargo-llvm-cov.nix
@@ -1,0 +1,64 @@
+# This package is marked broken upstream due to test failures and would be
+# built with a different version of `cargo`/`rust`, so we re-build it here.
+#
+# https://github.com/NixOS/nixpkgs/blob/16b7680853d2d0c7a120c21266eff4a2660a3207/pkgs/development/tools/rust/cargo-llvm-cov/default.nix
+{
+  fetchurl,
+  fetchFromGitHub,
+  craneLib,
+  git,
+}: let
+  pname = "cargo-llvm-cov";
+  version = "0.6.9";
+  owner = "taiki-e";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-fZrYmsulKOvgW/WtsYL7r4Cby+m9ShgXozxj1ZQ5ZAY=";
+  };
+
+  # The upstream repo doesn't include a `Cargo.lock`.
+  cargoLock = fetchurl {
+    name = "Cargo.lock";
+    url = "https://crates.io/api/v1/crates/${pname}/${version}/download";
+    sha256 = "sha256-r4C7z2/z4OVEf+IhFe061E7FzSx0VzADmg56Lb+DO/g=";
+    downloadToTemp = true;
+    postFetch = ''
+      tar xzf $downloadedFile ${pname}-${version}/Cargo.lock
+      mv ${pname}-${version}/Cargo.lock $out
+    '';
+  };
+
+  commonArgs' = {
+    inherit pname version src;
+
+    postUnpack = ''
+      cp ${cargoLock} source/Cargo.lock
+    '';
+
+    cargoVendorDir = craneLib.vendorCargoDeps {
+      inherit src cargoLock;
+    };
+  };
+
+  cargoArtifacts = craneLib.buildDepsOnly commonArgs';
+
+  commonArgs =
+    commonArgs'
+    // {
+      inherit cargoArtifacts;
+
+      nativeCheckInputs = [
+        git
+      ];
+
+      # `cargo-llvm-cov` tests rely on `git ls-files`.
+      preCheck = ''
+        git init -b main
+        git add .
+      '';
+    };
+in
+  craneLib.buildPackage commonArgs

--- a/nix/packages/ghciwatch.nix
+++ b/nix/packages/ghciwatch.nix
@@ -12,6 +12,8 @@
   rustPlatform,
   rust-analyzer,
   mdbook,
+  cargo-nextest,
+  cargo-llvm-cov,
   # Versions of GHC to include in the environment for integration tests.
   # These should be attributes of `haskell.compiler`.
   ghcVersions ? null,
@@ -178,16 +180,19 @@
     '';
   };
 
-  checks = {
-    ghciwatch-tests = craneLib.cargoNextest (commonArgs
-      // {
-        buildInputs = (commonArgs.buildInputs or []) ++ ghcBuildInputs;
-        NEXTEST_PROFILE = "ci";
-        NEXTEST_HIDE_PROGRESS_BAR = "true";
+  testArgs =
+    commonArgs
+    // {
+      nativeBuildInputs = (commonArgs.nativeBuildInputs or []) ++ ghcBuildInputs;
+      NEXTEST_PROFILE = "ci";
+      NEXTEST_HIDE_PROGRESS_BAR = "true";
 
-        # Provide GHC versions to use to the integration test suite.
-        inherit GHC_VERSIONS;
-      });
+      # Provide GHC versions to use to the integration test suite.
+      inherit GHC_VERSIONS;
+    };
+
+  checks = {
+    ghciwatch-tests = craneLib.cargoNextest testArgs;
     ghciwatch-clippy = craneLib.cargoClippy (commonArgs
       // {
         cargoClippyExtraArgs = "--all-targets -- --deny warnings";
@@ -203,6 +208,19 @@
       // {
         inherit (inputs) advisory-db;
       });
+    ghciwatch-coverage =
+      (craneLib.cargoLlvmCov.override {
+        inherit cargo-llvm-cov;
+      })
+      (testArgs
+        // {
+          cargoLlvmCovCommand = "nextest";
+          nativeBuildInputs =
+            (testArgs.nativeBuildInputs or [])
+            ++ [
+              cargo-nextest
+            ];
+        });
 
     # Check that the Haskell project used for integration tests is OK.
     haskell-project-for-integration-tests = stdenv.mkDerivation {


### PR DESCRIPTION
- Adds optional coverage reports for test runs via `cargo llvm-cov nextest`. 
- Also adds the `llvm-tools-preview` extension via Nix 
