### PR TITLE
Cleanup README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,3 +39,20 @@ possible. You'll need a Haskell installation including GHC, `cabal`, and
 executables named `ghc-9.6.5` and `ghc-9.8.2` on your `$PATH`.
 
 [hpack]: https://github.com/sol/hpack
+
+## Why Rust?
+
+Rust makes it easy to ship static binaries. Rust also shares many features with
+Haskell: a [Hindley-Milner type system][hm] with inference, pattern matching,
+and immutability by default. Rust can also [interoperate with
+Haskell][hs-bindgen], so in the future we'll be able to ship `ghciwatch` as a
+Hackage package natively. Also, Rust's commitment to stability makes coping
+with multiple GHC versions and GHC upgrades easy. Finally, Rust is home to the
+excellent cross-platform and battle-tested [`notify`][notify] library, used to
+implement the [`watchexec`][watchexec] binary and `cargo-watch`, which solves a
+lot of the thorny problems of watching files for us.
+
+[hm]: https://en.wikipedia.org/wiki/Hindley%E2%80%93Milner_type_system
+[hs-bindgen]: https://engineering.iog.io/2023-01-26-hs-bindgen-introduction/
+[watchexec]: https://github.com/watchexec/watchexec
+[notify]: https://docs.rs/notify/latest/notify/

--- a/README.md
+++ b/README.md
@@ -7,53 +7,50 @@
 <a href="https://repology.org/project/rust:ghciwatch/versions">
 <img src="https://repology.org/badge/vertical-allrepos/rust:ghciwatch.svg?header=" alt="Packaging status">
 </a>
+<br>
+<a href="https://mercurytechnologies.github.io/ghciwatch/">
+<img src="https://img.shields.io/badge/User%20manual-mercurytechnologies.github.io%2Fghciwatch-blue" alt="User manual">
+</a>
 
-The next generation of [`ghcid`][ghcid], a [`ghci`][ghci]-based file watcher
-and recompiler. `ghciwatch` watches your modules for changes and reloads them in
-a `ghci` session, displaying any errors.
+Ghciwatch loads a [GHCi][ghci] session for a Haskell project and reloads it
+when source files change.
 
-[ghcid]: https://github.com/ndmitchell/ghcid
 [ghci]: https://downloads.haskell.org/ghc/latest/docs/users_guide/ghci.html
 
+## Features
 
-## Why a reimplementation?
+- Ghciwatch can [clear the screen between reloads](https://mercurytechnologies.github.io/ghciwatch/cli.html#--clear).
+- Compilation errors can be written to a file with
+  [`--error-file`](https://mercurytechnologies.github.io/ghciwatch/cli.html#--error-file),
+  for compatibility with [ghcid's][ghcid] `--outputfile` option.
+- Comments starting with `-- $>` [can be
+  evaluated](https://mercurytechnologies.github.io/ghciwatch/comment-evaluation.html)
+  in GHCi.
+  - Eval comments have access to the top-level bindings of the module they're
+    defined in, including unexported bindings.
+  - Multi-line eval comments are supported with `{- $> ... <$ -}`.
+- A variety of [lifecycle
+  hooks](https://mercurytechnologies.github.io/ghciwatch/lifecycle-hooks.html)
+  let you run Haskell code or shell commands on a variety of events.
+  - Run a test suite with [`--test-ghci
+    TestMain.testMain`](https://mercurytechnologies.github.io/ghciwatch/cli.html#--test-ghci).
+  - Refresh your `.cabal` files with [`hpack`][hpack] before GHCi starts using
+    [`--before-startup-shell
+    hpack`](https://mercurytechnologies.github.io/ghciwatch/cli.html#--before-startup-shell).
+  - Format your code asynchronously using [`--before-reload-shell
+    async:fourmolu`](https://mercurytechnologies.github.io/ghciwatch/cli.html#--before-reload-shell).
+- [Custom
+  globs](https://mercurytechnologies.github.io/ghciwatch/cli.html#--reload-glob)
+  can be supplied to reload or restart the GHCi session when non-Haskell files
+  (like templates or database schema definitions) change.
+- Ghciwatch can handle new modules, removed modules, or moved modules without a
+  hitch, so you don't need to manually restart it.
 
-When we started working on `ghciwatch`, `ghcid` suffered from some significant
-limitations. In particular, `ghcid` couldn't deal with moved or deleted
-modules, and wouldn't detect new directories because it [can't easily update
-the set of files being watched at runtime.][ghcid-wait] We've also seen memory
-leaks requiring multiple restarts per day. Due to the `ghcid` codebase's
-relatively small size, a reimplementation seemed like a more efficient path
-forward than making wide-spanning changes to an unfamiliar codebase.
+[ghcid]: https://github.com/ndmitchell/ghcid
+[hpack]: https://github.com/sol/hpack
 
-[ghcid-wait]: https://github.com/ndmitchell/ghcid/blob/e2852979aa644c8fed92d46ab529d2c6c1c62b59/src/Wait.hs#L81-L83
+## Demo
 
+Check out a quick demo to see how ghciwatch feels in practice:
 
-## Why Rust?
-
-Rust makes it easy to ship static binaries. Rust also shares many features with
-Haskell: a [Hindley-Milner type system][hm] with inference, pattern matching,
-and immutability by default. Rust can also [interoperate with
-Haskell][hs-bindgen], so in the future we'll be able to ship `ghciwatch` as a
-Hackage package natively. Also, Rust's commitment to stability makes coping
-with multiple GHC versions and GHC upgrades easy. Finally, Rust is home to the
-excellent cross-platform and battle-tested [`notify`][notify] library, used to
-implement the [`watchexec`][watchexec] binary and `cargo-watch`, which solves a
-lot of the thorny problems of watching files for us.
-
-[hm]: https://en.wikipedia.org/wiki/Hindley%E2%80%93Milner_type_system
-[hs-bindgen]: https://engineering.iog.io/2023-01-26-hs-bindgen-introduction/
-[watchexec]: https://github.com/watchexec/watchexec
-[notify]: https://docs.rs/notify/latest/notify/
-
-
-## Why not just use `watchexec` or similar?
-
-Recompiling a project when files change is a fairly common development task, so
-there's a bunch of tools with this same rough goal. In particular,
-[`watchexec`][watchexec] is a nice off-the-shelf solution. Why not just run
-`watchexec -e hs cabal build`? In truth, `ghciwatch` doesn't just recompile the
-project when it detects changes. It instead manages an interactive `ghci`
-session, instructing it to reload modules when relevant. This involves a fairly
-complex dance of communicating to `ghci` over stdin and parsing its stdout, so
-a bespoke tool is useful here.
+<a href="https://asciinema.org/a/659712" target="_blank"><img src="https://asciinema.org/a/659712.svg" /></a>

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -7,3 +7,4 @@
 - [Lifecycle hooks](./lifecycle-hooks.md)
 - [Comment evaluation](./comment-evaluation.md)
 - [Only load modules you need](./no-load.md)
+- [FAQ](./faq.md)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,6 +37,20 @@ Don't reload for `README.md` files:
 
     ghciwatch --reload-glob '!src/**/README.md'
 
+## Arguments
+<dl>
+
+<dt><a id="FILE", href="#FILE"><code> &lt;FILE&gt;</code></a></dt><dd>
+
+A Haskell source file to load into a `ghci` REPL.
+
+Shortcut for `--command 'ghci PATH'`. Conflicts with `--command`.
+
+</dd>
+
+</dl>
+
+
 ## Options
 <dl>
 
@@ -73,6 +87,14 @@ Clear the screen before reloads and restarts
 Don't interrupt reloads when files change.
 
 Depending on your workflow, `ghciwatch` may feel more responsive with this set.
+
+</dd>
+<dt><a id="--completions" href="#--completions"><code>--completions &lt;COMPLETIONS&gt;</code></a></dt><dd>
+
+Generate shell completions for the given shell
+
+  Possible values: `bash`, `elvish`, `fish`, `powershell`, `zsh`
+
 
 </dd>
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,30 @@
+# FAQ
+
+## Why a reimplementation?
+
+Ghciwatch started out as a reimplementation and reimagination of
+[`ghcid`][ghcid], a similar tool with smaller scope. When we started working on
+ghciwatch, `ghcid` suffered from some significant limitations. In particular,
+`ghcid` couldn't deal with moved or deleted modules, and wouldn't detect new
+directories because it [can't easily update the set of files being watched at
+runtime.][ghcid-wait] We've also seen memory leaks requiring multiple restarts
+per day. Due to the `ghcid` codebase's relatively small size, a
+reimplementation seemed like a more efficient path forward than making
+wide-spanning changes to an unfamiliar codebase.
+
+[ghcid]: https://github.com/ndmitchell/ghcid
+[ghcid-wait]: https://github.com/ndmitchell/ghcid/blob/e2852979aa644c8fed92d46ab529d2c6c1c62b59/src/Wait.hs#L81-L83
+
+## Why not just use `watchexec` or similar?
+
+TL;DR: Managing a GHCi session is often faster than recompiling a project with
+`cabal` or similar.
+
+Recompiling a project when files change is a fairly common development task, so
+there's a bunch of tools with this same rough goal. In particular,
+[`watchexec`][watchexec] is a nice off-the-shelf solution. Why not just run
+`watchexec -e hs cabal build`? In truth, ghciwatch doesn't just recompile the
+project when it detects changes. It instead manages an interactive GHCi
+session, instructing it to reload modules when relevant. This involves a fairly
+complex dance of communicating to GHCi over stdin and parsing its stdout, so
+a bespoke tool is useful here.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -15,7 +15,7 @@ when source files change.
   - Eval comments have access to the top-level bindings of the module they're
     defined in, including unexported bindings.
   - Multi-line eval comments are supported with `{- $> ... <$ -}`.
-- A variety of [lifecycle hooks](lilifecycle-hooks.md) let you run Haskell code
+- A variety of [lifecycle hooks](lifecycle-hooks.md) let you run Haskell code
   or shell commands on a variety of events.
   - Run a test suite with [`--test-ghci
     TestMain.testMain`](cli.md#--test-ghci).


### PR DESCRIPTION
This makes the README mostly identical to the "Introduction" page of the manual.

- README.md gains a badge linking to the user manual
- "Why Rust?" moved into CONTRIBUTING.md
- "Why reimplement ghcid?" and "Why not use watchexec?" moved into a new FAQ page in the manual