### PR TITLE
Add PR/issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,27 @@
+name: Bug Report
+description: File a bug report.
+labels: ["bug", "triage"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce the issue
+      description: >-
+        Please be as specific as possible. A sample project is helpful here as
+        bugs are often sensitive to GHC options.
+
+  - type: input
+    id: version
+    attributes:
+      label: The version of ghciwatch with the bug
+      description: Output of `ghciwatch --version`

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,21 @@
+name: Feature request
+description: File a feature request.
+labels: ["feature", "triage"]
+body:
+  - type: textarea
+    id: feature
+    attributes:
+      label: Describe the feature you’d like to be implemented
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: List alternatives to the feature and their pros and cons
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: >-
+        Why do you want this feature implemented?
+        Why don't existing features cover your use-case?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+- [ ] Labeled the PR with `patch`, `minor`, or `major` to request a version bump when it's merged.
+- [ ] Updated the user manual in `docs/`.
+- [ ] Added integration / regression tests in `tests/`.


### PR DESCRIPTION
I don't think there's any way to validate these without merging them?