### PR TITLE
[NFCI] `Module` -> `CompilingModule`

### DIFF
--- a/src/ghci/parse/ghc_message/compiling.rs
+++ b/src/ghci/parse/ghc_message/compiling.rs
@@ -26,7 +26,7 @@ pub fn compiling(input: &mut &str) -> PResult<GhcMessage> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use module_and_files::Module;
+    use module_and_files::CompilingModule;
 
     use indoc::indoc;
     use pretty_assertions::assert_eq;
@@ -37,7 +37,7 @@ mod tests {
             compiling
                 .parse("[1 of 3] Compiling Foo ( Foo.hs, Foo.o, interpreted )\n")
                 .unwrap(),
-            GhcMessage::Compiling(Module {
+            GhcMessage::Compiling(CompilingModule {
                 name: "Foo".into(),
                 path: "Foo.hs".into()
             })
@@ -51,7 +51,7 @@ mod tests {
                       /Users/wiggles/doggy-web-backend6/dist-newstyle/build/aarch64-osx/ghc-9.6.2/doggy-web-backend-0/l/test-dev/noopt/build/test-dev/A/DoggyPrelude/Puppy.dyn_o \
                       ) [Doggy.Lint package changed]\n")
                 .unwrap(),
-            GhcMessage::Compiling(Module{
+            GhcMessage::Compiling(CompilingModule {
                 name: "A.DoggyPrelude.Puppy".into(),
                 path: "src/A/DoggyPrelude/Puppy.hs".into()
             })
@@ -61,7 +61,7 @@ mod tests {
             compiling
                 .parse("[1 of 4] Compiling MyLib            ( src/MyLib.hs )\n")
                 .unwrap(),
-            GhcMessage::Compiling(Module {
+            GhcMessage::Compiling(CompilingModule {
                 name: "MyLib".into(),
                 path: "src/MyLib.hs".into()
             })

--- a/src/ghci/parse/ghc_message/mod.rs
+++ b/src/ghci/parse/ghc_message/mod.rs
@@ -44,7 +44,7 @@ mod no_location_info_diagnostic;
 use no_location_info_diagnostic::no_location_info_diagnostic;
 
 use super::rest_of_line;
-use super::Module;
+use super::CompilingModule;
 
 /// A message printed by GHC or GHCi while compiling.
 ///
@@ -56,7 +56,7 @@ pub enum GhcMessage {
     /// ```text
     /// [1 of 2] Compiling Foo ( Foo.hs, interpreted )
     /// ```
-    Compiling(Module),
+    Compiling(CompilingModule),
     /// An error or warning diagnostic message.
     ///
     /// ```text
@@ -233,11 +233,11 @@ mod tests {
                 GhcMessage::LoadConfig {
                     path: "/Users/wiggles/.ghci".into()
                 },
-                GhcMessage::Compiling(Module {
+                GhcMessage::Compiling(CompilingModule {
                     name: "MyLib".into(),
                     path: "src/MyLib.hs".into(),
                 }),
-                GhcMessage::Compiling(Module {
+                GhcMessage::Compiling(CompilingModule {
                     name: "MyModule".into(),
                     path: "src/MyModule.hs".into(),
                 }),

--- a/src/ghci/parse/mod.rs
+++ b/src/ghci/parse/mod.rs
@@ -22,7 +22,7 @@ pub use ghc_message::CompilationSummary;
 pub use ghc_message::GhcDiagnostic;
 pub use ghc_message::GhcMessage;
 pub use ghc_message::Severity;
-pub use module_and_files::Module;
+pub use module_and_files::CompilingModule;
 pub use module_set::ModuleSet;
 pub use show_paths::parse_show_paths;
 pub use show_paths::ShowPaths;

--- a/src/ghci/parse/module_and_files.rs
+++ b/src/ghci/parse/module_and_files.rs
@@ -32,14 +32,14 @@ use super::module_name;
 /// Compiling A.Puppy.Doggy ( src/A/Puppy/Doggy.hs, dist-newstyle/A/Puppy/Doggy.o, interpreted ) [Doggy.Lint package changed]
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Module {
+pub struct CompilingModule {
     /// The module's fully-qualified name.
     pub name: String,
     /// The path to the module's source file, typically a `.hs` file.
     pub path: Utf8PathBuf,
 }
 
-impl FromStr for Module {
+impl FromStr for CompilingModule {
     type Err = miette::Report;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -52,7 +52,7 @@ impl FromStr for Module {
 /// ```text
 /// My.Cool.Module ( src/My/Cool/Module.hs, dist-newstyle/My/Cool/Module.o, interpreted )
 /// ```
-pub fn module_and_files(input: &mut &str) -> PResult<Module> {
+pub fn module_and_files(input: &mut &str) -> PResult<CompilingModule> {
     let module_name = module_name(input)?;
     let _ = space1.parse_next(input)?;
 
@@ -75,7 +75,7 @@ pub fn module_and_files(input: &mut &str) -> PResult<Module> {
             input,
             StrContext::Expected(StrContextValue::Description("a Haskell source file path")),
         ))),
-        Some(path) => Ok(Module {
+        Some(path) => Ok(CompilingModule {
             name: module_name.to_owned(),
             path,
         }),
@@ -92,8 +92,8 @@ mod tests {
     #[test]
     fn test_parse_module() {
         assert_eq!(
-            "A.MercuryPrelude ( src/A/MercuryPrelude.hs, /Users/wiggles/mwb4/dist-newstyle/build/aarch64-osx/ghc-9.6.1/mwb-0/l/test-dev/noopt/build/test-dev/A/MercuryPrelude.dyn_o )".parse::<Module>().unwrap(),
-            Module {
+            "A.MercuryPrelude ( src/A/MercuryPrelude.hs, /Users/wiggles/mwb4/dist-newstyle/build/aarch64-osx/ghc-9.6.1/mwb-0/l/test-dev/noopt/build/test-dev/A/MercuryPrelude.dyn_o )".parse::<CompilingModule>().unwrap(),
+            CompilingModule {
                 name: "A.MercuryPrelude".into(),
                 path: "src/A/MercuryPrelude.hs".into(),
             }
@@ -106,7 +106,7 @@ mod tests {
             module_and_files
                 .parse("Foo ( Foo.hs, Foo.o, interpreted )")
                 .unwrap(),
-            Module {
+            CompilingModule {
                 name: "Foo".into(),
                 path: "Foo.hs".into()
             }
@@ -119,7 +119,7 @@ mod tests {
                       /Users/wiggles/doggy-web-backend6/dist-newstyle/build/aarch64-osx/ghc-9.6.2/doggy-web-backend-0/l/test-dev/noopt/build/test-dev/A/DoggyPrelude/Puppy.dyn_o \
                       )")
                 .unwrap(),
-            Module{
+            CompilingModule{
                 name: "A.DoggyPrelude.Puppy".into(),
                 path: "src/A/DoggyPrelude/Puppy.hs".into()
             }
@@ -129,7 +129,7 @@ mod tests {
             module_and_files
                 .parse("MyLib            ( src/MyLib.hs )")
                 .unwrap(),
-            Module {
+            CompilingModule {
                 name: "MyLib".into(),
                 path: "src/MyLib.hs".into()
             }


### PR DESCRIPTION
This is the result of parsing a GHC message like

    [1 of 3] Compiling Foo ( Foo.hs, Foo.o, interpreted )

It is specifically for when a module is being compiled. In the future, we may parse out output names, the "1 of 3" bit, etc.

I'm thinking about adding a more complete `Module` type to go in the `ModuleSet` and I don't want name conflicts.