### PR TITLE
Fix `:show targets` / `:show paths` parsing logic

### DIFF
--- a/src/normal_path.rs
+++ b/src/normal_path.rs
@@ -201,4 +201,49 @@ mod tests {
 
         assert_eq!(test_path.into_absolute().as_os_str(), dir.as_os_str());
     }
+
+    #[test]
+    fn test_normalpath_new() {
+        let base = Utf8Path::new("/Users/wiggles/ghciwatch/tests/data/simple");
+        let relative = Utf8Path::new("src/MyLib.hs");
+        let path = NormalPath::new(relative, base).unwrap();
+
+        assert_eq!(
+            path.absolute(),
+            Utf8Path::new("/Users/wiggles/ghciwatch/tests/data/simple/src/MyLib.hs")
+        );
+        assert_eq!(path.relative(), Utf8Path::new("src/MyLib.hs"));
+    }
+
+    #[test]
+    fn test_normalpath_new_parent() {
+        let base = Utf8Path::new("/a/b/c");
+        let relative = Utf8Path::new("../puppy");
+        let path = NormalPath::new(relative, base).unwrap();
+
+        assert_eq!(path.absolute(), Utf8Path::new("/a/b/puppy"));
+        assert_eq!(path.relative(), Utf8Path::new("../puppy"));
+    }
+
+    #[test]
+    fn test_normalpath_new_unrelated() {
+        let base = Utf8Path::new("/a/b/c");
+        let relative = Utf8Path::new("/d/e/f");
+        let path = NormalPath::new(relative, base).unwrap();
+
+        assert_eq!(path.absolute(), Utf8Path::new("/d/e/f"));
+        // This is kinda silly; the paths share no components in common, they're both absolute, but
+        // we don't get an absolute path out of it.
+        assert_eq!(path.relative(), Utf8Path::new("../../../d/e/f"));
+    }
+
+    #[test]
+    fn test_normalpath_new_both_relative() {
+        let base = Utf8Path::new("a/b/c");
+        let relative = Utf8Path::new("d/e/f");
+        let path = NormalPath::new(relative, base).unwrap();
+
+        assert_eq!(path.absolute(), Utf8Path::new("a/b/c/d/e/f"));
+        assert_eq!(path.relative(), Utf8Path::new("d/e/f"));
+    }
 }


### PR DESCRIPTION
Previously, if `:show targets` displayed a path, we would attempt to join that path to each of the module search paths and to GHCi's working directory to find the file.

In reality, GHCi only checks such paths relative to its working directory. (Indeed, if you change the working directory with `:cd`, GHCi will unload all modules. [1])

Also, the logic for checking these paths was broken, considering that the search paths can be relative to the working directory, but we weren't properly joining these paths.

In the future, I'll write some tests that do `--after-startup-ghci ":cd ../"` and see how much of ghciwatch explodes.

[1]: https://gitlab.haskell.org/ghc/ghc/-/blob/077cb2e11fa81076e8c9c5f8dd3bdfa99c8aaf8d/compiler/GHC.hs#L1073-L1083
