### PR TITLE
[NFCI] Use `line_ending_or_eof` consistently in parsers

### DIFF
--- a/src/ghci/parse/eval.rs
+++ b/src/ghci/parse/eval.rs
@@ -7,7 +7,6 @@ use miette::miette;
 use winnow::ascii::line_ending;
 use winnow::ascii::space0;
 use winnow::combinator::alt;
-use winnow::combinator::eof;
 use winnow::combinator::opt;
 use winnow::combinator::peek;
 use winnow::combinator::repeat;
@@ -16,6 +15,7 @@ use winnow::Located;
 use winnow::PResult;
 use winnow::Parser;
 
+use crate::ghci::parse::lines::line_ending_or_eof;
 use crate::ghci::GhciCommand;
 
 use super::lines::rest_of_line;
@@ -173,7 +173,7 @@ fn multiline_eval_command(input: &mut Located<&str>) -> PResult<ByteSpanCommand>
             .with_span()
             .parse_next(input)?;
     multiline_eval_end.parse_next(input)?;
-    let _ = (space0, alt((line_ending, eof))).parse_next(input)?;
+    let _ = (space0, line_ending_or_eof).parse_next(input)?;
 
     Ok(ByteSpanCommand {
         // `command` ends with a newline so we put a newline after the `:{` but not before the

--- a/src/ghci/parse/ghc_message/compilation_summary.rs
+++ b/src/ghci/parse/ghc_message/compilation_summary.rs
@@ -1,10 +1,10 @@
 use winnow::ascii::digit1;
-use winnow::ascii::line_ending;
 use winnow::combinator::alt;
 use winnow::combinator::opt;
 use winnow::PResult;
 use winnow::Parser;
 
+use crate::ghci::parse::lines::line_ending_or_eof;
 use crate::ghci::parse::CompilationResult;
 
 use super::GhcMessage;
@@ -54,7 +54,7 @@ pub fn compilation_summary(input: &mut &str) -> PResult<GhcMessage> {
     let _ = " module".parse_next(input)?;
     let _ = opt("s").parse_next(input)?;
     let _ = " loaded.".parse_next(input)?;
-    let _ = line_ending.parse_next(input)?;
+    let _ = line_ending_or_eof.parse_next(input)?;
 
     Ok(GhcMessage::Summary(CompilationSummary {
         result,

--- a/src/ghci/parse/ghc_message/module_import_cycle_diagnostic.rs
+++ b/src/ghci/parse/ghc_message/module_import_cycle_diagnostic.rs
@@ -1,6 +1,5 @@
 use camino::Utf8PathBuf;
 use itertools::Itertools;
-use winnow::ascii::line_ending;
 use winnow::ascii::space1;
 use winnow::combinator::alt;
 use winnow::combinator::opt;
@@ -10,6 +9,7 @@ use winnow::PResult;
 use winnow::Parser;
 
 use crate::ghci::parse::haskell_grammar::module_name;
+use crate::ghci::parse::lines::line_ending_or_eof;
 use crate::ghci::parse::lines::rest_of_line;
 use crate::ghci::parse::Severity;
 
@@ -57,7 +57,7 @@ pub fn module_import_cycle_diagnostic(input: &mut &str) -> PResult<Vec<GhcMessag
             "Module graph contains a cycle:",
         ))
         .parse_next(input)?;
-        let _ = line_ending.parse_next(input)?;
+        let _ = line_ending_or_eof.parse_next(input)?;
         repeat(1.., parse_import_cycle_line).parse_next(input)
     }
 


### PR DESCRIPTION
This is useful for line-oriented parsers that may consume input with no trailing newline character. While this is a [violation of the POSIX spec][posix], VS Code [does it by default][vscode].

[posix]: https://stackoverflow.com/a/729795
[vscode]: https://stackoverflow.com/questions/44704968/visual-studio-code-insert-newline-at-the-end-of-files

Split off from #297
