### PR TITLE
Fix incorrect auto-scroll/follow behavior in TUI

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -146,7 +146,13 @@ impl Tui {
 
     fn maybe_follow(&mut self) {
         let height = self.size.height as usize;
-        if self.scroll_offset >= self.line_count - Saturating(height) - Saturating(1) {
+
+        let scrolled_to_bottom =
+            self.scroll_offset >= self.line_count - Saturating(height) - Saturating(1);
+
+        let scrollback_exceeds_height = self.line_count > Saturating(height);
+
+        if scrolled_to_bottom && scrollback_exceeds_height {
             self.scroll_offset += Saturating(1);
         }
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -159,53 +159,23 @@ impl Tui {
         // TODO: Steal Evan's declarative key matching macros?
         // https://github.com/evanrelf/indigo/blob/7a5e8e47291585cae03cdf5a7c47ad3bcd8db3e6/crates/indigo-tui/src/key/macros.rs
         match event {
-            Event::Mouse(mouse) if mouse.kind == MouseEventKind::ScrollUp => {
-                self.scroll_up(SCROLL_AMOUNT);
-            }
-            Event::Mouse(mouse) if mouse.kind == MouseEventKind::ScrollDown => {
-                self.scroll_down(SCROLL_AMOUNT);
-            }
-            Event::Key(key) => match key.modifiers {
-                KeyModifiers::NONE => match key.code {
-                    KeyCode::Char('j') => {
-                        self.scroll_down(1);
-                    }
-                    KeyCode::Char('k') => {
-                        self.scroll_up(1);
-                    }
-                    KeyCode::Char('g') => {
-                        self.scroll_to(0);
-                    }
-                    _ => {}
-                },
-
-                #[allow(clippy::single_match)]
-                KeyModifiers::SHIFT => match key.code {
-                    KeyCode::Char('g' | 'G') => {
-                        self.scroll_to(usize::MAX);
-                    }
-                    _ => {}
-                },
-
-                KeyModifiers::CONTROL => match key.code {
-                    KeyCode::Char('u') => {
-                        self.scroll_up(self.half_height().0);
-                    }
-                    KeyCode::Char('d') => {
-                        self.scroll_down(self.half_height().0);
-                    }
-                    KeyCode::Char('e') => {
-                        self.scroll_down(1);
-                    }
-                    KeyCode::Char('y') => {
-                        self.scroll_up(1);
-                    }
-                    KeyCode::Char('c') => {
-                        self.quit = true;
-                    }
-                    _ => {}
-                },
-
+            Event::Mouse(mouse) => match mouse.kind {
+                MouseEventKind::ScrollUp => self.scroll_up(SCROLL_AMOUNT),
+                MouseEventKind::ScrollDown => self.scroll_down(SCROLL_AMOUNT),
+                _ => {}
+            },
+            Event::Key(key) => match (key.modifiers, key.code) {
+                (KeyModifiers::NONE, KeyCode::Char('j')) => self.scroll_down(1),
+                (KeyModifiers::NONE, KeyCode::Char('k')) => self.scroll_up(1),
+                (KeyModifiers::NONE, KeyCode::Char('g')) => self.scroll_to(0),
+                (KeyModifiers::SHIFT, KeyCode::Char('g' | 'G')) => self.scroll_to(usize::MAX),
+                (KeyModifiers::CONTROL, KeyCode::Char('u')) => self.scroll_up(self.half_height().0),
+                (KeyModifiers::CONTROL, KeyCode::Char('d')) => {
+                    self.scroll_down(self.half_height().0)
+                }
+                (KeyModifiers::CONTROL, KeyCode::Char('e')) => self.scroll_down(1),
+                (KeyModifiers::CONTROL, KeyCode::Char('y')) => self.scroll_up(1),
+                (KeyModifiers::CONTROL, KeyCode::Char('c')) => self.quit = true,
                 _ => {}
             },
             _ => {}


### PR DESCRIPTION
The code to follow logs had a bug where it'd increment the scroll offset regardless of how much of the screen was filled, so on startup it would start "following", pushing the logs up off the top.

This PR adds a second check to wait until the logs have filled the screen before auto-incrementing the scroll offset to follow.

---

I also tweaked the formatting of the key mapping `match`es to be more readable (IMO) and introduced a rudimentary debug status bar (hidden by default) which was essential for understanding this bug and fixing it.

I've found keeping debug info like this readily available to be a huge boon when working on my text editor project. I recommend keeping this in the code, at least while the TUI is in an experimental stage. But I'm also happy to remove if you'd rather not include that change.

---

Commits are atomic; I recommend reviewing them individually.