### PR TITLE
Fix release workflow with PRs from forks

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -9,7 +9,7 @@
 # and update the `REPO_GITHUB_TOKEN` secret to a new, valid token.
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
     branches:

--- a/nix/packages/get-crate-version.nix
+++ b/nix/packages/get-crate-version.nix
@@ -1,30 +1,12 @@
 {
+  lib,
   writeShellApplication,
-  cargo,
-  jq,
+  ghciwatch,
 }:
 writeShellApplication {
   name = "get-crate-version";
 
-  runtimeInputs = [
-    cargo
-    jq
-  ];
-
   text = ''
-    # Gets the version of `ghciwatch` in `Cargo.toml` using
-    # `cargo metadata` and `jq`.
-
-    VERSION=$(cargo metadata --format-version 1 \
-        | jq -r '.packages[] | select(.name == "ghciwatch") | .version')
-
-    echo "Version in \`Cargo.toml\` is $VERSION" 1>&2
-
-    if [[ -z "$VERSION" ]]; then
-        echo "I wasn't able to determine the version in \`Cargo.toml\` with \`cargo metadata\`"
-        exit 1
-    fi
-
-    echo "$VERSION"
+    echo ${lib.escapeShellArg ghciwatch.version}
   '';
 }


### PR DESCRIPTION
PR #329 failed to create a release because the release workflow ran in the context of the fork:

```
Run peter-evans/create-pull-request@v5
Error: Input 'token' not supplied. Unable to continue.
Restore git configuration
  Error: Cannot read properties of undefined (reading 'removeAuth')
```

Change the workflow to run in `pull_request_target` to fix this, I hope.

Also update `get-crate-version` to not depend on any runtime tools, only the Nix expressions.

See: https://github.com/MercuryTechnologies/ghciwatch/actions/runs/12130981516/job/33822389311
