### PR TITLE
Update `flake.lock`, Rust toolchain, GHC

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1714183630,
-        "narHash": "sha256-1BVft7ggSN2XXFeXQjazU3jN9wVECd9qp2mZx/8GDMk=",
+        "lastModified": 1741367336,
+        "narHash": "sha256-QsTWsBWXvcrTHMhZK5sTz8Omyxn4tSszg/U5Y1BLzFM=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "35e7459a331d3e0c585e56dabd03006b9b354088",
+        "rev": "74ff50e899726ef85314978f60e9f7858462b21f",
         "type": "github"
       },
       "original": {
@@ -17,17 +17,12 @@
       }
     },
     "crane": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
       "locked": {
-        "lastModified": 1714536327,
-        "narHash": "sha256-zu4+LcygJwdyFHunTMeDFltBZ9+hoWvR/1A7IEy7ChA=",
+        "lastModified": 1741148495,
+        "narHash": "sha256-EV8KUaIZ2/CdBXlutXrHoZYbWPeB65p5kKZk71gvDRI=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "3124551aebd8db15d4560716d4f903bd44c64e4a",
+        "rev": "75390a36cd0c2cdd5f1aafd8a9f827d7107f2e53",
         "type": "github"
       },
       "original": {
@@ -39,44 +34,26 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
         "owner": "edolstra",
         "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714253743,
-        "narHash": "sha256-mdTQw2XlariysyScCv2tTE45QSU9v/ezLcHJ22f0Nxc=",
+        "lastModified": 1741246872,
+        "narHash": "sha256-Q6pMP4a9ed636qilcYX8XUguvKl/0/LGXhHcRI91p0U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "58a1abdbae3217ca6b702f03d3b35125d88a2994",
+        "rev": "10069ef4cf863633f57238f179a0297de84bd8d3",
         "type": "github"
       },
       "original": {
@@ -93,22 +70,21 @@
         "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay",
-        "systems": "systems_2"
+        "systems": "systems"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1714529851,
-        "narHash": "sha256-YMKJW880f7LHXVRzu93xa6Ek+QLECIu0IRQbXbzZe38=",
+        "lastModified": 1741314698,
+        "narHash": "sha256-6Yp0CTwAY/jq/F81Sa8NM0Zi1EwxAdASO6y4A5neGuc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9ca720fdcf7865385ae3b93ecdf65f1a64cb475e",
+        "rev": "4e9af61c1a631886cdc7e13032af4fc9e75bb76b",
         "type": "github"
       },
       "original": {
@@ -118,21 +94,6 @@
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -73,9 +73,6 @@
     # GHC versions to include in the environment for integration tests.
     # Keep this in sync with `./test-harness/src/ghc_version.rs`.
     ghcVersions = [
-      "ghc90"
-      "ghc92"
-      "ghc94"
       "ghc96"
       "ghc98"
     ];

--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
           (
             final: prev: {
               # TODO: Bump the Rust version here...
-              rustToolchain = final.pkgsBuildHost.rust-bin.stable."1.72.1".default.override {
+              rustToolchain = final.pkgsBuildHost.rust-bin.stable."1.81.0".default.override {
                 targets =
                   final.lib.optionals final.stdenv.targetPlatform.isDarwin [
                     "x86_64-apple-darwin"

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,6 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     crane = {
       url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
     };
     systems.url = "github:nix-systems/default";
     rust-overlay = {

--- a/nix/packages/checks/treefmt.nix
+++ b/nix/packages/checks/treefmt.nix
@@ -13,7 +13,7 @@ mkCheck {
   ];
 
   checkPhase = ''
-    treefmt --fail-on-change
+    HOME="$PWD" treefmt --fail-on-change
   '';
 
   meta.description = ''

--- a/nix/packages/ghciwatch.nix
+++ b/nix/packages/ghciwatch.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  libiconv,
+  pkgsStatic,
   darwin,
   buildPackages,
   haskell,
@@ -56,10 +56,7 @@
 
       nativeBuildInputs = lib.optionals stdenv.isDarwin [
         # Additional darwin specific inputs can be set here
-        (libiconv.override {
-          enableStatic = true;
-          enableShared = false;
-        })
+        pkgsStatic.libiconv
         darwin.apple_sdk.frameworks.CoreServices
       ];
 

--- a/src/clap_markdown/formatter.rs
+++ b/src/clap_markdown/formatter.rs
@@ -283,7 +283,7 @@ where
         if arg.is_positional() {
             let id = arg
                 .get_value_names()
-                .and_then(|names| names.get(0))
+                .and_then(|names| names.first())
                 .map(|name| name.as_str())
                 .unwrap_or_else(|| arg.get_id().as_str());
 

--- a/src/ghci/loaded_module.rs
+++ b/src/ghci/loaded_module.rs
@@ -73,7 +73,7 @@ impl PartialEq for LoadedModule {
 
 impl PartialOrd for LoadedModule {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.path.partial_cmp(&other.path)
+        Some(self.cmp(other))
     }
 }
 

--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -294,10 +294,7 @@ impl Ghci {
             prompt_patterns: AhoCorasick::from_anchored_patterns([PROMPT]),
         };
 
-        let stdin = GhciStdin {
-            stdin,
-            stderr_sender: stderr_sender.clone(),
-        };
+        let stdin = GhciStdin { stdin };
 
         shutdown
             .spawn("stderr", |shutdown| {

--- a/src/ghci/stdin.rs
+++ b/src/ghci/stdin.rs
@@ -3,14 +3,12 @@ use miette::Context;
 use miette::IntoDiagnostic;
 use tokio::io::AsyncWriteExt;
 use tokio::process::ChildStdin;
-use tokio::sync::mpsc;
 use tracing::instrument;
 
 use crate::incremental_reader::FindAt;
 
 use super::loaded_module::LoadedModule;
 use super::parse::ShowPaths;
-use super::stderr::StderrEvent;
 use super::CompilationLog;
 use super::GhciCommand;
 use super::ModuleSet;
@@ -20,8 +18,6 @@ use crate::ghci::GhciStdout;
 pub struct GhciStdin {
     /// Inner stdin writer.
     pub stdin: ChildStdin,
-    /// Channel sender for communicating with the stderr task.
-    pub stderr_sender: mpsc::Sender<StderrEvent>,
 }
 
 impl GhciStdin {

--- a/test-harness/Cargo.toml
+++ b/test-harness/Cargo.toml
@@ -12,7 +12,7 @@ fs_extra = "1.3.0"
 futures-util = "0.3.28"
 itertools = "0.11.0"
 miette = { version = "5.9.0", features = ["fancy"] }
-nix = { version = "0.26.2", default_features = false, features = ["process", "signal"] }
+nix = { version = "0.26.2", default-features = false, features = ["process", "signal"] }
 regex = "1.9.4"
 serde = { version = "1.0.186", features = ["derive"] }
 serde_json = "1.0.105"

--- a/test-harness/src/fs.rs
+++ b/test-harness/src/fs.rs
@@ -77,6 +77,7 @@ impl Fs {
             }
             OpenOptions::new()
                 .create(true)
+                .append(true)
                 .write(true)
                 .open(path)
                 .await

--- a/test-harness/src/ghciwatch.rs
+++ b/test-harness/src/ghciwatch.rs
@@ -429,7 +429,7 @@ impl GhciWatch {
     /// Returns the first matching event.
     pub fn assert_logged_in_checkpoint(
         &self,
-        checkpoints: impl CheckpointIndex + Clone,
+        checkpoints: impl CheckpointIndex,
         matcher: impl IntoMatcher,
     ) -> miette::Result<&Event> {
         let mut matcher = matcher.into_matcher()?;

--- a/test-harness/src/internal.rs
+++ b/test-harness/src/internal.rs
@@ -16,16 +16,16 @@ use tokio::process::Child;
 thread_local! {
     /// The temporary directory where `ghciwatch` is run. Note that because tests are run with the
     /// `tokio` current-thread runtime, this is unique per-test.
-    pub(crate) static TEMPDIR: RefCell<Option<PathBuf>> = RefCell::new(None);
+    pub(crate) static TEMPDIR: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
 
     /// The GHC version to use for this test. This should be a string like `ghc962`.
     /// This is used to select the correct GHC version to run.
-    pub(crate) static GHC_VERSION: RefCell<String> = RefCell::new(String::new());
+    pub(crate) static GHC_VERSION: RefCell<String> = const { RefCell::new(String::new()) };
 
     /// The `ghciwatch` process for this test.
     ///
     /// This is set so that we can make sure to kill it when the test ends.
-    pub(crate) static GHCIWATCH_PROCESS: RefCell<Option<Child>> = RefCell::new(None);
+    pub(crate) static GHCIWATCH_PROCESS: RefCell<Option<Child>> = const { RefCell::new(None) };
 }
 
 /// Wraps an asynchronous test with startup/cleanup code.

--- a/test-harness/src/tracing_json.rs
+++ b/test-harness/src/tracing_json.rs
@@ -30,7 +30,7 @@ pub struct Event {
 
 impl Event {
     /// Get an iterator over this event's spans, from the outside in (root to leaf).
-    pub fn spans(&self) -> impl Iterator<Item = &Span> + DoubleEndedIterator {
+    pub fn spans(&self) -> impl DoubleEndedIterator<Item = &Span> {
         self.spans.iter().chain({
             // The `new`, `exit`, and `close` span lifecycle events aren't emitted from inside the
             // relevant span, so the span isn't listed in `spans`. Instead, the relevant span is in


### PR DESCRIPTION
- Update `flake.lock` to update `nixpkgs` and other inputs
- Update Rust toolchain from 1.72.1 to 1.81.0