### PR TITLE
[DUX-3004]: handle evil clients that send ANSI escapes after NL

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@
 
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
+// This is a false lint triggered due to expect_test generated code.
+#![allow(clippy::needless_raw_string_hashes)]
 
 mod aho_corasick;
 mod buffers;


### PR DESCRIPTION
Wew. That was a bug.

The reproducer is here: https://github.com/rampion/ghciwatch-bug-demo

After tracing `consume_str`, I found out that the cause of our problems is that hspec includes the NL in their coloured output before resetting colour.

https://github.com/hspec/hspec/blob/fb9916f07e580f2572220d381e1886e765df95b7/hspec-core/src/Test/Hspec/Core/Formatters/Internal.hs#L297-L306

That means that it is a pain in the ass to parse, since it shoves random ANSI escapes onto the next line. The easiest, and probably most correct, solution to this is to just eat ANSI escapes while looking for markers.

- [x] Labeled the PR with `patch`, `minor`, or `major` to request a version bump when it's merged.
- [ ] Updated the user manual in `docs/`.
- [ ] Added integration / regression tests in `tests/`.
