### PR TITLE
[DUX-1897]: more clear output for interpreting modules for eval

### DIFF
--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -567,7 +567,6 @@ impl Ghci {
         // restore the old value when the function returns.
         for (path, commands) in self.eval_commands.clone() {
             for command in commands {
-                tracing::info!("{path}:{command}");
                 // If the `module` was already compiled, `ghci` may have loaded the interface file instead
                 // of the interpreted bytecode, giving us this error message when we attempt to
                 // load the top-level scope with `:module + *{module}`:
@@ -577,8 +576,10 @@ impl Ghci {
                 // We use `:add *{module}` to force interpreting the module. We do this here instead of in
                 // `add_module` to save time if eval commands aren't used (or aren't needed for a
                 // particular module).
+                tracing::info!("Loading {path} in interpreted mode for eval commands");
                 self.interpret_module(&path, log).await?;
                 let module = self.search_paths.path_to_module(&path)?;
+                tracing::info!("Eval {path}:{command}");
                 self.stdin
                     .eval(&mut self.stdout, &module, &command.command, log)
                     .await?;

--- a/src/ghci/parse/eval.rs
+++ b/src/ghci/parse/eval.rs
@@ -39,7 +39,11 @@ pub struct EvalCommand {
 
 impl Display for EvalCommand {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}:{}: {}", self.line, self.column, self.display_command)
+        write!(
+            f,
+            "{}:{}: -- $> {}",
+            self.line, self.column, self.display_command
+        )
     }
 }
 


### PR DESCRIPTION
This output was confusing and adding another log line does make it clearer what it's doing even though it just takes a couple of seconds.

- [ ] Labeled the PR with `patch`, `minor`, or `major` to request a version bump when it's merged.
- [ ] Updated the user manual in `docs/`.
- [ ] Added integration / regression tests in `tests/`.
