### PR TITLE
humantime: 2.1.0 -> 2.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "ignore"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ clearscreen = "2.0.1"
 command-group = { version = "2.1.0", features = ["tokio", "with-tokio"] }
 crossterm = { version = "0.27.0", features = ["event-stream"] }
 enum-iterator = "1.4.1"
-humantime = "2.1.0"
+humantime = "2.3.0"
 ignore = "0.4.20"
 indoc = "1.0.6"
 itertools = "0.11.0"

--- a/src/clap/humantime.rs
+++ b/src/clap/humantime.rs
@@ -40,12 +40,8 @@ impl TypedValueParser for DurationValueParser {
                     code: None,
                     severity: None,
                     help: match &err {
-                        DurationError::InvalidCharacter(index) => {
-                            if &str_value[*index..*index + 1] == "." {
-                                Some("Decimals are not supported".to_owned())
-                            } else {
-                                Some("Non-alphanumeric characters are prohibited".to_owned())
-                            }
+                        DurationError::InvalidCharacter(_) => {
+                            Some("Non-alphanumeric characters are prohibited".to_owned())
                         }
                         DurationError::NumberExpected(_) => {
                             Some("Did you split a unit into multiple words?".to_owned())


### PR DESCRIPTION
This allows usage like `ghciwatch --debounce 0.1s`. Previously, decimals were not supported, so you had to do (e.g.) `--debounce 100ms`, which was not very intuitive.

See: https://github.com/chronotope/humantime/pull/56
