### PR TITLE
Reduce default debounce interval to 0.1s

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -142,7 +142,7 @@ pub struct WatchOpts {
     // arguments? I have no clue!
     #[arg(
         long,
-        default_value = "500ms",
+        default_value = "100ms",
         value_name = "DURATION",
         value_parser = crate::clap::DurationValueParser::default(),
     )]


### PR DESCRIPTION
- [ ] Labeled the PR with `patch`, `minor`, or `major` to request a version bump when it's merged.
- [ ] Updated the user manual in `docs/`.
- [ ] Added integration / regression tests in `tests/`.

See #356.