### PR TITLE
Batch file modification events to reduce compile looping

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -87,6 +87,8 @@ Clear the screen before reloads and restarts
 
 Don't interrupt reloads when files change.
 
+When set, in-progress reloads run to completion. Any file changes that arrive during a reload are batched and applied in a single follow-up reload, rather than interrupting the current one.
+
 Depending on your workflow, `ghciwatch` may feel more responsive with this set.
 
 </dd>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -67,6 +67,10 @@ pub struct Opts {
 
     /// Don't interrupt reloads when files change.
     ///
+    /// When set, in-progress reloads run to completion. Any file changes that arrive during
+    /// a reload are batched and applied in a single follow-up reload, rather than interrupting
+    /// the current one.
+    ///
     /// Depending on your workflow, `ghciwatch` may feel more responsive with this set.
     #[arg(long)]
     pub no_interrupt_reloads: bool,

--- a/src/ghci/manager.rs
+++ b/src/ghci/manager.rs
@@ -97,6 +97,21 @@ pub async fn run_ghci(
             }
         };
 
+        // Greedily drain any additional pending events and merge them, so that rapid successive
+        // writes produce a single recompile instead of one per event.
+        loop {
+            match receiver.try_recv() {
+                Ok(pending_event) => {
+                    tracing::debug!(?pending_event, "Merging pending event");
+                    event.merge(pending_event);
+                }
+                Err(mpsc::error::TryRecvError::Empty) => break,
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    return Err(miette!("ghci event channel closed"));
+                }
+            }
+        }
+
         // This channel notifies us what kind of reload is triggered, which we can use to inform
         // our decision to interrupt the reload or not.
         let (reload_sender, reload_receiver) = oneshot::channel();
@@ -129,6 +144,13 @@ pub async fn run_ghci(
                     // Send a SIGINT to interrupt the reload.
                     // NB: This may take a couple seconds to register.
                     ghci.lock().await.send_sigint().await?;
+                } else {
+                    // Don't interrupt, but don't lose the event either.
+                    maybe_event = Some(new_event);
+                    // Wait for the current task to finish before the next iteration.
+                    let ret = task.await;
+                    ret.into_diagnostic()??;
+                    tracing::debug!("Finished dispatching ghci event (new event queued)");
                 }
             }
             ret = &mut task => {

--- a/test-harness/src/ghciwatch.rs
+++ b/test-harness/src/ghciwatch.rs
@@ -43,6 +43,7 @@ pub struct GhciWatchBuilder {
     default_timeout: Duration,
     startup_timeout: Duration,
     log_filters: Vec<String>,
+    poll_interval: String,
 }
 
 impl GhciWatchBuilder {
@@ -58,6 +59,7 @@ impl GhciWatchBuilder {
             default_timeout: Duration::from_secs(10),
             startup_timeout: Duration::from_secs(60),
             log_filters: Default::default(),
+            poll_interval: "1000ms".to_owned(),
         }
     }
 
@@ -149,6 +151,14 @@ impl GhciWatchBuilder {
     /// Add a `--log-filter` clause to the `ghciwatch` invocation.
     pub fn with_log_filter(mut self, log_filter: impl AsRef<str>) -> Self {
         self.log_filters.push(log_filter.as_ref().to_owned());
+        self
+    }
+
+    /// Set the `--poll` interval for the file watcher.
+    ///
+    /// The default is `1000ms`.
+    pub fn with_poll_interval(mut self, interval: impl AsRef<str>) -> Self {
+        self.poll_interval = interval.as_ref().to_owned();
         self
     }
 
@@ -316,7 +326,7 @@ impl GhciWatch {
                 "--trace-spans",
                 "new,close",
                 "--poll",
-                "1000ms",
+                &builder.poll_interval,
             ])
             .args(builder.ghciwatch_args)
             .current_dir(&cwd)

--- a/tests/data/slow-compile/.gitignore
+++ b/tests/data/slow-compile/.gitignore
@@ -1,0 +1,2 @@
+/my-slow-package.cabal
+/dist-newstyle

--- a/tests/data/slow-compile/Makefile
+++ b/tests/data/slow-compile/Makefile
@@ -1,0 +1,46 @@
+CABAL_OPTS ?=
+CABAL ?= cabal \
+	$(if $(GHC), --with-compiler=$(GHC)) \
+	$(CABAL_OPTS)
+
+EXTRA_GHC_OPTS ?=
+GHC_OPTS ?= \
+	-fwrite-interface \
+	$(EXTRA_GHC_OPTS)
+
+GHCI_OPTS ?= \
+	$(GHC_OPTS) \
+	-hisuf ghci_hi
+
+CABAL_REPL ?= $(CABAL) \
+	--repl-options='$(GHCI_OPTS)' \
+	v2-repl lib:test-dev
+
+GHCIWATCH_OPTS ?=
+GHCIWATCH ?= ../../../target/release/ghciwatch \
+	--command "$(CABAL_REPL)" \
+	--before-startup-shell "make my-slow-package.cabal" \
+	--watch src \
+	--watch test \
+	--watch test-main \
+	$(GHCIWATCH_OPTS)
+
+my-slow-package.cabal: package.yaml
+	hpack .
+
+.PHONY: build
+build: my-slow-package.cabal
+	$(CABAL) --ghc-options='$(GHC_OPTS)' build lib:test-dev
+
+.PHONY: test
+test: my-slow-package.cabal build
+	$(CABAL) test
+	echo ":quit" | $(CABAL_REPL)
+
+.PHONY: ghci
+ghci: my-slow-package.cabal
+	$(CABAL_REPL)
+
+.PHONY: ghciwatch
+ghciwatch:
+	$(GHCIWATCH)

--- a/tests/data/slow-compile/cabal.project
+++ b/tests/data/slow-compile/cabal.project
@@ -1,0 +1,5 @@
+packages: my-slow-package.cabal
+offline: True
+flags: +local-dev
+package *
+  ghc-options: -fdiagnostics-color=always

--- a/tests/data/slow-compile/package.yaml
+++ b/tests/data/slow-compile/package.yaml
@@ -1,0 +1,53 @@
+---
+spec-version: 0.36.0
+verbatim:
+  cabal-version: 3.0
+name: my-slow-package
+version: 0.1.0.0
+
+ghc-options: -Wall
+
+dependencies:
+  - base
+  - template-haskell
+
+flags:
+  local-dev:
+    description: Turn on development settings, like auto-reload templates.
+    manual: true
+    default: false
+
+library:
+  source-dirs: src
+
+tests:
+  test:
+    main: Main.hs
+    source-dirs:
+      - test-main
+    ghc-options: -threaded -rtsopts -with-rtsopts=-N
+    when:
+    - condition: flag(local-dev)
+      then:
+        dependencies:
+        - test-dev
+      else:
+        dependencies:
+        - my-slow-package
+        - test-lib
+
+internal-libraries:
+  test-lib:
+    source-dirs:
+      - test
+
+  test-dev:
+    source-dirs:
+      - test
+      - src
+    when:
+    - condition: flag(local-dev)
+      then:
+        buildable: true
+      else:
+        buildable: false

--- a/tests/data/slow-compile/src/ExtraA.hs
+++ b/tests/data/slow-compile/src/ExtraA.hs
@@ -1,0 +1,4 @@
+module ExtraA (extraA) where
+
+extraA :: String
+extraA = "A"

--- a/tests/data/slow-compile/src/ExtraB.hs
+++ b/tests/data/slow-compile/src/ExtraB.hs
@@ -1,0 +1,4 @@
+module ExtraB (extraB) where
+
+extraB :: String
+extraB = "B"

--- a/tests/data/slow-compile/src/ExtraC.hs
+++ b/tests/data/slow-compile/src/ExtraC.hs
@@ -1,0 +1,4 @@
+module ExtraC (extraC) where
+
+extraC :: String
+extraC = "C"

--- a/tests/data/slow-compile/src/MyLib.hs
+++ b/tests/data/slow-compile/src/MyLib.hs
@@ -1,0 +1,4 @@
+module MyLib (someFunc) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"

--- a/tests/data/slow-compile/src/MyModule.hs
+++ b/tests/data/slow-compile/src/MyModule.hs
@@ -1,0 +1,4 @@
+module MyModule (example) where
+
+example :: String
+example = "example"

--- a/tests/data/slow-compile/src/SlowModule.hs
+++ b/tests/data/slow-compile/src/SlowModule.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE TemplateHaskell #-}
+module SlowModule (slowValue) where
+
+import MyLib (someFunc)
+import Control.Concurrent (threadDelay)
+import Language.Haskell.TH
+
+-- Import MyLib so that any change to MyLib.hs forces SlowModule to recompile,
+-- re-running the TH splice (4 second sleep). This gives tests a reliable
+-- window to queue file-change events while a reload is in progress.
+$(do
+    runIO $ threadDelay 500000
+    [d| slowValue :: Int
+        slowValue = 42 |]
+ )

--- a/tests/data/slow-compile/src/SlowModule.hs
+++ b/tests/data/slow-compile/src/SlowModule.hs
@@ -6,7 +6,7 @@ import Control.Concurrent (threadDelay)
 import Language.Haskell.TH
 
 -- Import MyLib so that any change to MyLib.hs forces SlowModule to recompile,
--- re-running the TH splice (4 second sleep). This gives tests a reliable
+-- re-running the TH splice (500ms sleep). This gives tests a reliable
 -- window to queue file-change events while a reload is in progress.
 $(do
     runIO $ threadDelay 500000

--- a/tests/data/slow-compile/test-main/Main.hs
+++ b/tests/data/slow-compile/test-main/Main.hs
@@ -1,0 +1,6 @@
+module Main where
+
+import TestMain (testMain)
+
+main :: IO ()
+main = testMain

--- a/tests/data/slow-compile/test/TestMain.hs
+++ b/tests/data/slow-compile/test/TestMain.hs
@@ -1,0 +1,6 @@
+module TestMain (testMain) where
+
+import System.IO (hPutStrLn, stderr)
+
+testMain :: IO ()
+testMain = hPutStrLn stderr "0 tests executed, 0 failures :)"

--- a/tests/event_coalesce.rs
+++ b/tests/event_coalesce.rs
@@ -1,0 +1,109 @@
+use test_harness::test;
+use test_harness::BaseMatcher;
+use test_harness::GhciWatch;
+use test_harness::GhciWatchBuilder;
+
+/// Test that rapid file modifications are handled correctly, either by being
+/// coalesced into a single reload or by being processed sequentially without
+/// losing events.
+#[test]
+async fn rapid_file_changes_are_not_lost() {
+    let mut session = GhciWatch::new("tests/data/simple")
+        .await
+        .expect("ghciwatch starts");
+    session
+        .wait_until_ready()
+        .await
+        .expect("ghciwatch loads ghci");
+
+    // Use `append` which has no load-bearing sleep, so both writes happen
+    // back-to-back. The poll watcher should detect both changes in the same
+    // cycle, causing them to be queued together on the channel and coalesced
+    // by the greedy drain in `run_ghci`.
+    session
+        .fs()
+        .append(
+            session.path("src/MyLib.hs"),
+            "\nhello = 1 :: Integer\n",
+        )
+        .await
+        .unwrap();
+    session
+        .fs()
+        .append(
+            session.path("src/MyModule.hs"),
+            "\nworld = 2 :: Integer\n",
+        )
+        .await
+        .unwrap();
+
+    // Both files' changes should be processed (either as a single coalesced
+    // reload or as sequential reloads) and compilation should succeed.
+    session
+        .wait_for_log(BaseMatcher::compilation_succeeded())
+        .await
+        .expect("compilation succeeds after rapid writes");
+}
+
+/// Test that events are not silently lost when `--no-interrupt-reloads` is set
+/// and a new file change arrives during an in-progress reload.
+///
+/// Before the fix, the new event was consumed from the channel but never acted
+/// upon, causing the file change to be silently dropped.
+#[test]
+async fn no_interrupt_reloads_preserves_events() {
+    let mut session = GhciWatchBuilder::new("tests/data/simple")
+        .with_arg("--no-interrupt-reloads")
+        .start()
+        .await
+        .expect("ghciwatch starts");
+    session
+        .wait_until_ready()
+        .await
+        .expect("ghciwatch loads ghci");
+
+    // Modify first file to trigger a reload.
+    session
+        .fs()
+        .append(
+            session.path("src/MyLib.hs"),
+            "\nhello = 1 :: Integer\n",
+        )
+        .await
+        .unwrap();
+
+    // Wait for the reload to begin.
+    session
+        .wait_until_reload()
+        .await
+        .expect("first reload starts");
+
+    // Modify second file. This may arrive while the first reload is still in
+    // progress. With `--no-interrupt-reloads`, the reload won't be interrupted,
+    // but the event must be preserved for the next iteration.
+    session
+        .fs()
+        .append(
+            session.path("src/MyModule.hs"),
+            "\nworld = 2 :: Integer\n",
+        )
+        .await
+        .unwrap();
+
+    // Wait for the first reload to finish.
+    session
+        .wait_for_log(BaseMatcher::reload_completes())
+        .await
+        .expect("first reload completes");
+
+    // The second file's changes must eventually trigger another reload.
+    // Before the fix, this event was silently dropped and would time out here.
+    session
+        .wait_until_reload()
+        .await
+        .expect("second reload starts for queued event");
+    session
+        .wait_for_log(BaseMatcher::reload_completes())
+        .await
+        .expect("second reload completes");
+}

--- a/tests/event_coalesce.rs
+++ b/tests/event_coalesce.rs
@@ -1,59 +1,29 @@
+use std::time::Duration;
+
 use test_harness::test;
 use test_harness::BaseMatcher;
-use test_harness::GhciWatch;
 use test_harness::GhciWatchBuilder;
+// These tests use `tests/data/slow-compile`, which contains a TemplateHaskell
+// module (`SlowModule`) that sleeps for 500ms at compile time. This makes
+// reloads that touch SlowModule slow enough for file-change events to arrive
+// mid-reload, exercising the event batching code paths.
 
-/// Test that rapid file modifications are handled correctly, either by being
-/// coalesced into a single reload or by being processed sequentially without
-/// losing events.
-#[test]
-async fn rapid_file_changes_are_not_lost() {
-    let mut session = GhciWatch::new("tests/data/simple")
-        .await
-        .expect("ghciwatch starts");
-    session
-        .wait_until_ready()
-        .await
-        .expect("ghciwatch loads ghci");
-
-    // Use `append` which has no load-bearing sleep, so both writes happen
-    // back-to-back. The poll watcher should detect both changes in the same
-    // cycle, causing them to be queued together on the channel and coalesced
-    // by the greedy drain in `run_ghci`.
-    session
-        .fs()
-        .append(
-            session.path("src/MyLib.hs"),
-            "\nhello = 1 :: Integer\n",
-        )
-        .await
-        .unwrap();
-    session
-        .fs()
-        .append(
-            session.path("src/MyModule.hs"),
-            "\nworld = 2 :: Integer\n",
-        )
-        .await
-        .unwrap();
-
-    // Both files' changes should be processed (either as a single coalesced
-    // reload or as sequential reloads) and compilation should succeed.
-    session
-        .wait_for_log(BaseMatcher::compilation_succeeded())
-        .await
-        .expect("compilation succeeds after rapid writes");
-}
-
-/// Test that events are not silently lost when `--no-interrupt-reloads` is set
-/// and a new file change arrives during an in-progress reload.
+/// Test that edits made during an in-progress compile are batched into a single
+/// follow-up compile, rather than triggering one compile per edit.
 ///
-/// Before the fix, the new event was consumed from the channel but never acted
-/// upon, causing the file change to be silently dropped.
+/// Scenario: a compile is running, we make 3 edits before it finishes, and
+/// expect exactly one more compile afterward containing all 3 edits.
+///
+/// Uses `--no-interrupt-reloads` so the in-progress compile runs to completion
+/// while events queue up, exercising the event preservation in the `else`
+/// branch and the greedy drain that merges pending events.
 #[test]
-async fn no_interrupt_reloads_preserves_events() {
-    let mut session = GhciWatchBuilder::new("tests/data/simple")
+async fn edits_during_compile_are_batched() {
+    let mut session = GhciWatchBuilder::new("tests/data/slow-compile")
         .with_arg("--no-interrupt-reloads")
+        .with_poll_interval("100ms")
+        .with_default_timeout(Duration::from_secs(30))
+        .with_startup_timeout(Duration::from_secs(120))
         .start()
         .await
         .expect("ghciwatch starts");
@@ -62,48 +32,71 @@ async fn no_interrupt_reloads_preserves_events() {
         .await
         .expect("ghciwatch loads ghci");
 
-    // Modify first file to trigger a reload.
+    // Modify SlowModule.hs to trigger a slow reload. GHCi only re-runs TH
+    // splices for modules whose source files actually changed, so we must
+    // modify SlowModule.hs itself (not a dependency).
     session
         .fs()
         .append(
-            session.path("src/MyLib.hs"),
-            "\nhello = 1 :: Integer\n",
+            session.path("src/SlowModule.hs"),
+            "\nslowExtra = 99 :: Int\n",
         )
         .await
         .unwrap();
 
-    // Wait for the reload to begin.
+    // Wait for the slow reload to begin.
     session
         .wait_until_reload()
         .await
         .expect("first reload starts");
 
-    // Modify second file. This may arrive while the first reload is still in
-    // progress. With `--no-interrupt-reloads`, the reload won't be interrupted,
-    // but the event must be preserved for the next iteration.
+    // While the reload is running, make 3 edits using `append` (no
+    // load-bearing sleep). All 3 writes land almost simultaneously, so the
+    // watcher detects them in the same poll cycle and they arrive on the
+    // channel while the slow reload is still in progress.
     session
         .fs()
         .append(
-            session.path("src/MyModule.hs"),
-            "\nworld = 2 :: Integer\n",
+            session.path("src/ExtraA.hs"),
+            "\nextraA2 = 1 :: Integer\n",
+        )
+        .await
+        .unwrap();
+    session
+        .fs()
+        .append(
+            session.path("src/ExtraB.hs"),
+            "\nextraB2 = 2 :: Integer\n",
+        )
+        .await
+        .unwrap();
+    session
+        .fs()
+        .append(
+            session.path("src/ExtraC.hs"),
+            "\nextraC2 = 3 :: Integer\n",
         )
         .await
         .unwrap();
 
-    // Wait for the first reload to finish.
+    // Wait for the first (slow) reload to finish.
     session
         .wait_for_log(BaseMatcher::reload_completes())
         .await
         .expect("first reload completes");
 
-    // The second file's changes must eventually trigger another reload.
-    // Before the fix, this event was silently dropped and would time out here.
+    // The follow-up reload should contain ALL 3 edited files in a single
+    // reload (merged). Without the fix, events are silently dropped and each
+    // file triggers its own separate reload.
     session
-        .wait_until_reload()
+        .wait_for_log(BaseMatcher::message(
+            "(?s)Reloading ghci:.*ExtraA.*ExtraB.*ExtraC",
+        ))
         .await
-        .expect("second reload starts for queued event");
+        .expect("second reload includes all 3 edited files in one reload");
+
     session
-        .wait_for_log(BaseMatcher::reload_completes())
+        .wait_for_log(BaseMatcher::compilation_succeeded())
         .await
-        .expect("second reload completes");
+        .expect("second reload compiles successfully");
 }

--- a/tests/event_coalesce.rs
+++ b/tests/event_coalesce.rs
@@ -56,26 +56,17 @@ async fn edits_during_compile_are_batched() {
     // channel while the slow reload is still in progress.
     session
         .fs()
-        .append(
-            session.path("src/ExtraA.hs"),
-            "\nextraA2 = 1 :: Integer\n",
-        )
+        .append(session.path("src/ExtraA.hs"), "\nextraA2 = 1 :: Integer\n")
         .await
         .unwrap();
     session
         .fs()
-        .append(
-            session.path("src/ExtraB.hs"),
-            "\nextraB2 = 2 :: Integer\n",
-        )
+        .append(session.path("src/ExtraB.hs"), "\nextraB2 = 2 :: Integer\n")
         .await
         .unwrap();
     session
         .fs()
-        .append(
-            session.path("src/ExtraC.hs"),
-            "\nextraC2 = 3 :: Integer\n",
-        )
+        .append(session.path("src/ExtraC.hs"), "\nextraC2 = 3 :: Integer\n")
         .await
         .unwrap();
 


### PR DESCRIPTION
Currently, `ghciwatch` stores events in a queue. If you have a long running compile going, this causes ghciwatch to collect file watch events, and then issue an `:add` and reload for each item in the queue. With AI agents, it is not uncommon for them to make an edit to a dozen files, each in rapid succession, *but* not so rapid that ghciwatch registers it as a single event. This queues up a dozen recompiles! Worse yet, sometimes these recompile events don't even add any new modules to the module set. For a large enough module set, we're waiting ~8-15 seconds per queue item.

This PR combines events in the queue, issuing a combined reload and `:add`. This significantly reduces the number of spurious compiles that must happen, which significantly reduces real latency in workflows that involve editing multiple files rapidly.

- [x] Updated the user manual in `docs/`.
- [x] Added integration / regression tests in `tests/`.

I've tested this locally on the mwb codebase and it works like a charm. Vastly better UX.
