### PR TITLE
CARDI-731 Extract out `FileClassifier`

### DIFF
--- a/src/ghci/file_classifier.rs
+++ b/src/ghci/file_classifier.rs
@@ -1,0 +1,174 @@
+//! Classifies file events into reload actions based on glob patterns.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use camino::Utf8PathBuf;
+
+use crate::event_filter::FileEvent;
+use crate::haskell_source_file::is_haskell_source_file;
+use crate::ignore::GlobMatcher;
+use crate::normal_path::NormalPath;
+
+use super::module_set::ModuleSet;
+use super::GhciReloadKind;
+
+/// Classifies file events into reload actions based on glob patterns
+/// and the current state of loaded modules.
+///
+/// This struct can be used both as a component of [`super::Ghci`] and standalone
+/// (e.g., during GHCi initialization, before the full session is available).
+#[derive(Debug, Clone)]
+pub struct FileClassifier {
+    /// Restart the `ghci` session when paths matching these globs are changed.
+    restart_globs: GlobMatcher,
+    /// Reload the `ghci` session when paths matching these globs are changed.
+    reload_globs: GlobMatcher,
+    /// The working directory used to make paths relative.
+    cwd: Utf8PathBuf,
+}
+
+impl FileClassifier {
+    /// Construct a new `FileClassifier` from glob matchers, using the process's
+    /// current working directory.
+    ///
+    /// This is suitable for use before GHCi has initialized.
+    pub fn new(restart_globs: GlobMatcher, reload_globs: GlobMatcher) -> miette::Result<Self> {
+        Ok(Self {
+            restart_globs,
+            reload_globs,
+            cwd: crate::current_dir_utf8()?,
+        })
+    }
+
+    /// Update the working directory (typically after `:show paths` is parsed).
+    pub fn set_cwd(&mut self, cwd: Utf8PathBuf) {
+        self.cwd = cwd;
+    }
+
+    /// Make a path relative to the working directory.
+    pub fn relative_path(&self, path: impl AsRef<Path>) -> miette::Result<NormalPath> {
+        NormalPath::new(path, &self.cwd)
+    }
+
+    /// Classify a set of file events into reload actions.
+    ///
+    /// `targets` is the set of currently loaded modules. Pass `&ModuleSet::default()` when
+    /// GHCi has not yet initialized (all Haskell modifications will be classified as "add").
+    pub(crate) fn classify(
+        &self,
+        events: BTreeSet<FileEvent>,
+        targets: &ModuleSet,
+    ) -> miette::Result<ReloadActions> {
+        // Once we know which paths were modified and which paths were removed, we can combine
+        // that with information about this `ghci` session to determine which modules need to be
+        // reloaded, which modules need to be added, and which modules were removed. In the case
+        // of removed modules, the entire `ghci` session must be restarted.
+        let mut needs_restart = Vec::new();
+        let mut needs_reload = Vec::new();
+        let mut needs_add = Vec::new();
+        let mut needs_remove = Vec::new();
+        for event in events {
+            let path = event.as_path();
+            let path = self.relative_path(path)?;
+
+            let restart_match = self.restart_globs.matched(&path);
+            let reload_match = self.reload_globs.matched(&path);
+            let path_is_haskell_source_file = is_haskell_source_file(&path);
+            tracing::trace!(
+                ?event,
+                ?restart_match,
+                ?reload_match,
+                is_haskell_source_file = path_is_haskell_source_file,
+                "Checking path"
+            );
+
+            // Don't restart if we've explicitly ignored this path in a glob.
+            if !restart_match.is_ignore()
+                // Restart on `.cabal` and `.ghci` files.
+                && (path
+                    .extension()
+                    .map(|ext| ext == "cabal")
+                    .unwrap_or(false)
+                || path
+                    .file_name()
+                    .map(|name| name == ".ghci")
+                    .unwrap_or(false)
+                // Restart on explicit restart globs.
+                || restart_match.is_whitelist())
+            {
+                // Restart for this path.
+                tracing::debug!(%path, "Needs restart");
+                needs_restart.push(path);
+            } else if reload_match.is_ignore() {
+                // Ignoring this path, continue.
+            } else if matches!(event, FileEvent::Remove(_))
+                && path_is_haskell_source_file
+                && targets.contains_source_path(&path)
+            {
+                tracing::debug!(%path, "Needs remove");
+                needs_remove.push(path);
+            } else if matches!(event, FileEvent::Modify(_)) && path_is_haskell_source_file {
+                // Otherwise, reload when Haskell files are modified.
+                if targets.contains_source_path(&path) {
+                    // We can `:reload` paths in the target set.
+                    tracing::debug!(%path, "Needs reload");
+                    needs_reload.push(path);
+                } else {
+                    // Otherwise we need to `:add` the new paths.
+                    tracing::debug!(%path, "Needs add");
+                    needs_add.push(path);
+                }
+            } else if reload_match.is_whitelist() {
+                // Extra extensions are always reloaded, never added.
+                tracing::debug!(%path, "Needs reload");
+                needs_reload.push(path);
+            }
+        }
+
+        Ok(ReloadActions {
+            needs_restart,
+            needs_reload,
+            needs_add,
+            needs_remove,
+        })
+    }
+}
+
+/// Actions needed to perform a reload.
+///
+/// See [`super::Ghci::reload`].
+#[derive(Debug)]
+pub(crate) struct ReloadActions {
+    /// Paths to modules which need a full `ghci` restart.
+    pub needs_restart: Vec<NormalPath>,
+    /// Paths to modules which need a `:reload`.
+    pub needs_reload: Vec<NormalPath>,
+    /// Paths to modules which need an `:add`.
+    pub needs_add: Vec<NormalPath>,
+    /// Paths to modules which need an `:unadd`.
+    pub needs_remove: Vec<NormalPath>,
+}
+
+impl ReloadActions {
+    /// Do any modules need to be added, removed, or reloaded?
+    pub fn needs_modify(&self) -> bool {
+        !self.needs_add.is_empty() || !self.needs_reload.is_empty() || !self.needs_remove.is_empty()
+    }
+
+    /// Is a session restart needed?
+    pub fn needs_restart(&self) -> bool {
+        !self.needs_restart.is_empty()
+    }
+
+    /// Get the kind of reload we'll perform.
+    pub fn kind(&self) -> GhciReloadKind {
+        if self.needs_restart() {
+            GhciReloadKind::Restart
+        } else if self.needs_modify() {
+            GhciReloadKind::Reload
+        } else {
+            GhciReloadKind::None
+        }
+    }
+}

--- a/src/ghci/manager.rs
+++ b/src/ghci/manager.rs
@@ -59,6 +59,7 @@ pub async fn run_ghci(
     // is a little different each time, so the `select!`s can't be consolidated.
 
     let no_interrupt_reloads = opts.no_interrupt_reloads;
+    let _classifier = opts.file_classifier()?;
     let mut ghci = Ghci::new(handle.clone(), opts)
         .await
         .wrap_err("Failed to start `ghci`")?;

--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -11,7 +11,6 @@ use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::fmt::Debug;
 use std::io::IsTerminal;
-use std::path::Path;
 use std::process::ExitStatus;
 use std::process::Stdio;
 use std::time::Instant;
@@ -69,6 +68,10 @@ mod progress_writer;
 mod module_set;
 pub use module_set::ModuleSet;
 
+mod file_classifier;
+pub use file_classifier::FileClassifier;
+use file_classifier::ReloadActions;
+
 mod loaded_module;
 use loaded_module::LoadedModule;
 
@@ -79,7 +82,6 @@ use crate::cli::Opts;
 use crate::clonable_command::ClonableCommand;
 use crate::event_filter::FileEvent;
 use crate::format_bulleted_list;
-use crate::haskell_source_file::is_haskell_source_file;
 use crate::hooks;
 use crate::hooks::HookOpts;
 use crate::hooks::LifecycleEvent;
@@ -205,6 +207,14 @@ impl GhciOpts {
         ))
     }
 
+    /// Create a [`FileClassifier`] from these options.
+    ///
+    /// The classifier uses the process's current working directory. Call
+    /// [`FileClassifier::set_cwd`] after GHCi initialization to update it.
+    pub fn file_classifier(&self) -> miette::Result<FileClassifier> {
+        FileClassifier::new(self.restart_globs.clone(), self.reload_globs.clone())
+    }
+
     #[instrument(skip_all, level = "trace")]
     fn clear(&self) {
         if self.clear {
@@ -238,6 +248,8 @@ pub struct Ghci {
     restart_sender: mpsc::Sender<()>,
     /// Writer for `ghcid`-compatible output, useful for editor integration for diagnostics.
     error_log: ErrorLog,
+    /// Classifies file events into reload actions based on glob patterns.
+    classifier: FileClassifier,
     /// The set of targets for this `ghci` session, from `:show targets`.
     ///
     /// Targets that fail to compile don't show up in `:show modules` and aren't, technically
@@ -357,6 +369,8 @@ impl Ghci {
             .await;
 
         let error_log = ErrorLog::new(opts.error_path.clone());
+        let classifier =
+            FileClassifier::new(opts.restart_globs.clone(), opts.reload_globs.clone())?;
 
         Ok(Ghci {
             opts,
@@ -366,6 +380,7 @@ impl Ghci {
             stdout,
             restart_sender,
             error_log,
+            classifier,
             targets: Default::default(),
             eval_commands: Default::default(),
             search_paths: ShowPaths {
@@ -403,82 +418,8 @@ impl Ghci {
         Ok(())
     }
 
-    async fn get_reload_actions(
-        &self,
-        events: BTreeSet<FileEvent>,
-    ) -> miette::Result<ReloadActions> {
-        // Once we know which paths were modified and which paths were removed, we can combine
-        // that with information about this `ghci` session to determine which modules need to be
-        // reloaded, which modules need to be added, and which modules were removed. In the case
-        // of removed modules, the entire `ghci` session must be restarted.
-        let mut needs_restart = Vec::new();
-        let mut needs_reload = Vec::new();
-        let mut needs_add = Vec::new();
-        let mut needs_remove = Vec::new();
-        for event in events {
-            let path = event.as_path();
-            let path = self.relative_path(path)?;
-
-            let restart_match = self.opts.restart_globs.matched(&path);
-            let reload_match = self.opts.reload_globs.matched(&path);
-            let path_is_haskell_source_file = is_haskell_source_file(&path);
-            tracing::trace!(
-                ?event,
-                ?restart_match,
-                ?reload_match,
-                is_haskell_source_file = path_is_haskell_source_file,
-                "Checking path"
-            );
-
-            // Don't restart if we've explicitly ignored this path in a glob.
-            if !restart_match.is_ignore()
-                // Restart on `.cabal` and `.ghci` files.
-                && (path
-                    .extension()
-                    .map(|ext| ext == "cabal")
-                    .unwrap_or(false)
-                || path
-                    .file_name()
-                    .map(|name| name == ".ghci")
-                    .unwrap_or(false)
-                // Restart on explicit restart globs.
-                || restart_match.is_whitelist())
-            {
-                // Restart for this path.
-                tracing::debug!(%path, "Needs restart");
-                needs_restart.push(path);
-            } else if reload_match.is_ignore() {
-                // Ignoring this path, continue.
-            } else if matches!(event, FileEvent::Remove(_))
-                && path_is_haskell_source_file
-                && self.targets.contains_source_path(&path)
-            {
-                tracing::debug!(%path, "Needs remove");
-                needs_remove.push(path);
-            } else if matches!(event, FileEvent::Modify(_)) && path_is_haskell_source_file {
-                // Otherwise, reload when Haskell files are modified.
-                if self.targets.contains_source_path(&path) {
-                    // We can `:reload` paths in the target set.
-                    tracing::debug!(%path, "Needs reload");
-                    needs_reload.push(path);
-                } else {
-                    // Otherwise we need to `:add` the new paths.
-                    tracing::debug!(%path, "Needs add");
-                    needs_add.push(path);
-                }
-            } else if reload_match.is_whitelist() {
-                // Extra extensions are always reloaded, never added.
-                tracing::debug!(%path, "Needs reload");
-                needs_reload.push(path);
-            }
-        }
-
-        Ok(ReloadActions {
-            needs_restart,
-            needs_reload,
-            needs_add,
-            needs_remove,
-        })
+    fn get_reload_actions(&self, events: BTreeSet<FileEvent>) -> miette::Result<ReloadActions> {
+        self.classifier.classify(events, &self.targets)
     }
 
     /// Reload this `ghci` session to include the given modified and removed paths.
@@ -494,7 +435,7 @@ impl Ghci {
         kind_sender: oneshot::Sender<GhciReloadKind>,
     ) -> miette::Result<()> {
         let start_instant = Instant::now();
-        let actions = self.get_reload_actions(events).await?;
+        let actions = self.get_reload_actions(events)?;
         let _ = kind_sender.send(actions.kind());
 
         if actions.needs_restart() {
@@ -636,6 +577,7 @@ impl Ghci {
     #[instrument(skip_all, level = "debug")]
     async fn refresh_paths(&mut self) -> miette::Result<()> {
         self.search_paths = self.stdin.show_paths(&mut self.stdout).await?;
+        self.classifier.set_cwd(self.search_paths.cwd.clone());
         tracing::debug!(cwd = %self.search_paths.cwd, search_paths = ?self.search_paths.search_paths, "Parsed paths");
         Ok(())
     }
@@ -849,11 +791,6 @@ impl Ghci {
         Ok(())
     }
 
-    /// Make a path relative to the `ghci` session's current working directory.
-    fn relative_path(&self, path: impl AsRef<Path>) -> miette::Result<NormalPath> {
-        self.search_paths.make_relative(path)
-    }
-
     #[instrument(skip_all, level = "debug")]
     async fn send_sigint(&mut self) -> miette::Result<()> {
         let start_instant = Instant::now();
@@ -970,44 +907,6 @@ impl Ghci {
     #[instrument(skip(self), level = "trace")]
     async fn write_error_log(&mut self, log: &CompilationLog) -> miette::Result<()> {
         self.error_log.write(log).await
-    }
-}
-
-/// Actions needed to perform a reload.
-///
-/// See [`Ghci::reload`].
-#[derive(Debug)]
-struct ReloadActions {
-    /// Paths to modules which need a full `ghci` restart.
-    needs_restart: Vec<NormalPath>,
-    /// Paths to modules which need a `:reload`.
-    needs_reload: Vec<NormalPath>,
-    /// Paths to modules which need an `:add`.
-    needs_add: Vec<NormalPath>,
-    /// Paths to modules which need an `:unadd`.
-    needs_remove: Vec<NormalPath>,
-}
-
-impl ReloadActions {
-    /// Do any modules need to be added, removed, or reloaded?
-    fn needs_modify(&self) -> bool {
-        !self.needs_add.is_empty() || !self.needs_reload.is_empty() || !self.needs_remove.is_empty()
-    }
-
-    /// Is a session restart needed?
-    fn needs_restart(&self) -> bool {
-        !self.needs_restart.is_empty()
-    }
-
-    /// Get the kind of reload we'll perform.
-    fn kind(&self) -> GhciReloadKind {
-        if self.needs_restart() {
-            GhciReloadKind::Restart
-        } else if self.needs_modify() {
-            GhciReloadKind::Reload
-        } else {
-            GhciReloadKind::None
-        }
     }
 }
 

--- a/src/ghci/parse/show_paths.rs
+++ b/src/ghci/parse/show_paths.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::path::Path;
 
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
@@ -31,11 +30,6 @@ pub struct ShowPaths {
 }
 
 impl ShowPaths {
-    /// Make a path relative to the working directory of this session.
-    pub fn make_relative(&self, path: impl AsRef<Path>) -> miette::Result<NormalPath> {
-        NormalPath::new(path, &self.cwd)
-    }
-
     /// Convert a target (from `:show targets` output) to a module source path.
     pub fn target_to_path(&self, target: &str) -> miette::Result<LoadedModule> {
         let target_path = Utf8Path::new(target);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub(crate) use format_bulleted_list::format_bulleted_list;
 pub(crate) use string_case::StringCase;
 
 pub use ghci::manager::run_ghci;
+pub use ghci::FileClassifier;
 pub use ghci::Ghci;
 pub use ghci::GhciOpts;
 pub use ghci::GhciWriter;


### PR DESCRIPTION
When ghciwatch fails to start the underlying GHCi session (because of a bulid failure in a dependent package), it currently exits. We'd like it to wait around and attempt to restart GHCi after files change.

The logic for determining which file changes are worth restarting for is currently inside the `Ghci` struct, meaning we can't use it once the GHCi session dies.

Let's extract it so we can use it in the `Ghci` manager.