### PR TITLE
Handle compilation failures in dependencies during startup 

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -13,3 +13,4 @@
 
 - [Tasty](./integration/tasty.md)
 - [Multiple Cabal components](./integration/multiple-components.md)
+- [Multiple Cabal packages](./integration/multiple-packages.md)

--- a/docs/integration/multiple-components.md
+++ b/docs/integration/multiple-components.md
@@ -1,11 +1,13 @@
 # Multiple Cabal components
 
-Currently, multiple Cabal components don't work. You can work around this with
-[the Cabal `test-dev` trick][test-dev] as described by the venerable Jade
-Lovelace. This works by defining a new component in our `.cabal` file which
-includes the sources from the library and the tests, which has the added
-benefit of speeding up compile times by allowing the compilation of different
-components to be interleaved.
+Currently, multiple Cabal components don't work nicely with GHCi/ghciwatch
+(note that this is different from [multiple Cabal
+_packages_](multiple-components.md), which _also_ don't work). You can work
+around this with [the Cabal `test-dev` trick][test-dev] as described by the
+venerable Jade Lovelace. This works by defining a new component in our `.cabal`
+file which includes the sources from the library and the tests, which has the
+added benefit of speeding up compile times by allowing the compilation of
+different components to be interleaved.
 
 [test-dev]: https://jade.fyi/blog/cabal-test-dev-trick/
 

--- a/docs/integration/multiple-packages.md
+++ b/docs/integration/multiple-packages.md
@@ -1,0 +1,29 @@
+# Multiple Cabal packages / startup failures
+
+If you have a workspace with multiple Cabal packages, you might want to restart
+GHCi when those packages change.
+
+If you have something like this in your `cabal.project`:
+
+```
+packages:
+  my-package.cabal
+  my-dependency/my-dependency.cabal
+```
+
+Then, to trigger restarts when `my-dependency` changes, add something like this
+to your ghciwatch command:
+
+```
+ghciwatch \
+    --watch my-dependency \
+    --restart-glob 'my-dependency/src/**/*.hs' \
+    --restart-glob 'my-dependency/my-dependency.cabal'
+```
+
+Note that you'll need to specify each dependency manually; Cabal doesn't expose
+this information nicely for us to use automatically.
+
+Ghciwatch will wait for a glob match to change if the GHCi session fails to
+start. If you find it hanging around when you want it to be restarting, try
+adding to your `--restart-glob` or `--reload-glob` arguments.

--- a/src/ghci/manager.rs
+++ b/src/ghci/manager.rs
@@ -1,6 +1,7 @@
 //! Subsystem for [`Ghci`] to support graceful shutdown.
 
 use std::collections::BTreeSet;
+use std::process::ExitStatus;
 use std::sync::Arc;
 
 use miette::miette;
@@ -17,9 +18,11 @@ use crate::hooks;
 use crate::hooks::LifecycleEvent;
 use crate::shutdown::ShutdownHandle;
 
+use super::FileClassifier;
 use super::Ghci;
 use super::GhciOpts;
 use super::GhciReloadKind;
+use super::ModuleSet;
 
 /// An event sent to [`Ghci`] by the watcher.
 #[derive(Debug, Clone)]
@@ -59,19 +62,68 @@ pub async fn run_ghci(
     // is a little different each time, so the `select!`s can't be consolidated.
 
     let no_interrupt_reloads = opts.no_interrupt_reloads;
-    let _classifier = opts.file_classifier()?;
-    let mut ghci = Ghci::new(handle.clone(), opts)
+    let classifier = opts.file_classifier()?;
+    let (exited_sender, mut exited_receiver) = mpsc::channel::<ExitStatus>(1);
+    let mut ghci = Ghci::new(handle.clone(), opts, exited_sender)
         .await
         .wrap_err("Failed to start `ghci`")?;
 
     // Wait for ghci to finish loading.
     let mut log = CompilationLog::default();
-    tokio::select! {
+    // Use biased select with exited_receiver before startup_result. When ghci dies, its stdout
+    // closes and read_until enters a yield loop (returning Ok(None) on each EOF read), so
+    // startup_result never completes. exited_receiver.recv() fires once GhciProcess detects the
+    // exit, and with biased polling it is guaranteed to win once a message is available.
+    let startup_exit: Option<ExitStatus> = tokio::select! {
+        biased;
         _ = handle.on_shutdown_requested() => {
             ghci.stop().await.wrap_err("Failed to quit ghci")?;
+            return Ok(());
         }
+        Some(status) = exited_receiver.recv() => Some(status),
         startup_result = ghci.initialize(&mut log, [LifecycleEvent::Startup(hooks::When::After)]) => {
+            // Only reachable if ghci starts successfully (startup_result = Ok) or if
+            // initialization fails for a non-EOF reason (e.g., a lifecycle hook error).
             startup_result?;
+            None
+        }
+    };
+    if let Some(mut status) = startup_exit {
+        loop {
+            tracing::warn!(
+                ?status,
+                "ghci exited during startup; waiting for a file change to restart"
+            );
+            tokio::select! {
+                _ = handle.on_shutdown_requested() => {
+                    tracing::debug!("ghci is already dead; nothing to stop");
+                    return Ok(());
+                }
+                ret = receiver.recv() => {
+                    let event = ret.ok_or_else(|| miette!("ghci event channel closed"))?;
+                    let WatcherEvent::Reload { events } = event;
+                    let actions = classifier.classify(events, &ModuleSet::default())?;
+                    if matches!(actions.kind(), GhciReloadKind::None) {
+                        tracing::debug!("File change not relevant to ghci; continuing to wait");
+                        continue;
+                    }
+                }
+            }
+            tracing::debug!("Restarting ghci");
+            // Race restart() against exited_receiver. When ghci dies during restart's
+            // initialize(), read_until loops with yields rather than erroring (to avoid a
+            // race with exited_receiver). So restart() will never return on its own when
+            // ghci dies — exited_receiver fires first, and with biased polling it wins.
+            tokio::select! {
+                biased;
+                Some(new_status) = exited_receiver.recv() => {
+                    status = new_status;
+                }
+                result = ghci.restart() => {
+                    result.wrap_err("Failed to restart ghci after startup failure")?;
+                    break;
+                }
+            }
         }
     }
 
@@ -79,7 +131,7 @@ pub async fn run_ghci(
     // The event to respond to. If we interrupt a reload, we may begin the loop with `Some(_)` in
     // here.
     let mut maybe_event = None;
-    loop {
+    'main: loop {
         let mut event = match maybe_event.take() {
             Some(event) => event,
             None => {
@@ -91,6 +143,13 @@ pub async fn run_ghci(
                     }
                     ret = receiver.recv() => {
                         ret.ok_or_else(|| miette!("ghci event channel closed"))?
+                    }
+                    Some(status) = exited_receiver.recv() => {
+                        match wait_and_restart(&ghci, &mut handle, &mut receiver, &mut exited_receiver, &classifier, status).await? {
+                            RetryResult::Restarted => {},
+                            RetryResult::Shutdown => break 'main,
+                        }
+                        continue 'main;
                     }
                 };
                 tracing::debug!(?event, "Received ghci event from watcher");
@@ -108,12 +167,18 @@ pub async fn run_ghci(
             event.clone(),
             reload_sender,
         )));
+        let mut dispatch_exit = None;
         tokio::select! {
             _ = handle.on_shutdown_requested() => {
                 // Cancel any in-progress reloads. This releases the lock so we don't block here.
                 task.abort();
                 ghci.lock().await.stop().await.wrap_err("Failed to quit ghci")?;
                 break;
+            }
+            Some(status) = exited_receiver.recv() => {
+                // ghci died during the dispatch. Abort the stuck task to release the Mutex.
+                task.abort();
+                dispatch_exit = Some(status);
             }
             Some(new_event) = receiver.recv() => {
                 tracing::debug!(?new_event, "Received ghci event from watcher while reloading");
@@ -135,6 +200,23 @@ pub async fn run_ghci(
             ret = &mut task => {
                 ret.into_diagnostic()??;
                 tracing::debug!("Finished dispatching ghci event");
+            }
+        }
+
+        // If ghci died during the dispatch, wait for a file change and restart.
+        if let Some(status) = dispatch_exit {
+            match wait_and_restart(
+                &ghci,
+                &mut handle,
+                &mut receiver,
+                &mut exited_receiver,
+                &classifier,
+                status,
+            )
+            .await?
+            {
+                RetryResult::Restarted => {}
+                RetryResult::Shutdown => break,
             }
         }
     }
@@ -176,6 +258,69 @@ async fn should_interrupt(reload_receiver: oneshot::Receiver<GhciReloadKind>) ->
         GhciReloadKind::Reload => {
             tracing::debug!(?reload_kind, "Interrupting reload");
             true
+        }
+    }
+}
+
+/// Outcome of [`wait_and_restart`].
+enum RetryResult {
+    /// ghci was successfully restarted.
+    Restarted,
+    /// A shutdown was requested while waiting.
+    Shutdown,
+}
+
+/// Wait for a relevant file change, then attempt to restart ghci.
+///
+/// If ghci also dies during the restart attempt, keeps waiting for file changes and retrying
+/// rather than crashing. Returns [`RetryResult::Shutdown`] if a shutdown is requested while
+/// waiting.
+#[instrument(level = "debug", skip_all)]
+async fn wait_and_restart(
+    ghci: &Arc<Mutex<Ghci>>,
+    handle: &mut ShutdownHandle,
+    receiver: &mut mpsc::Receiver<WatcherEvent>,
+    exited_receiver: &mut mpsc::Receiver<ExitStatus>,
+    classifier: &FileClassifier,
+    mut status: ExitStatus,
+) -> miette::Result<RetryResult> {
+    loop {
+        tracing::warn!(
+            ?status,
+            "ghci exited unexpectedly; waiting for a file change to restart"
+        );
+        // Wait for a watcher event to use as a restart trigger. We must also handle shutdown
+        // here; otherwise if shutdown is requested while we're waiting, the watcher exits, its
+        // sender drops, and receiver.recv() would return None and crash instead of shutting
+        // down cleanly.
+        tokio::select! {
+            _ = handle.on_shutdown_requested() => {
+                // ghci is already dead; nothing to stop.
+                return Ok(RetryResult::Shutdown);
+            }
+            ret = receiver.recv() => {
+                let event = ret.ok_or_else(|| miette!("ghci event channel closed"))?;
+                let WatcherEvent::Reload { events } = event;
+                let actions = classifier.classify(events, &ModuleSet::default())?;
+                if matches!(actions.kind(), GhciReloadKind::None) {
+                    tracing::debug!("File change not relevant to ghci; continuing to wait");
+                    continue;
+                }
+            }
+        }
+        // Race restart() against exited_receiver. When ghci dies during restart's
+        // initialize(), read_until loops with yields (rather than erroring on EOF), so
+        // restart() never completes on its own. exited_receiver fires when GhciProcess
+        // detects the exit, and with biased polling it wins first so we can retry.
+        tokio::select! {
+            biased;
+            Some(new_status) = exited_receiver.recv() => {
+                status = new_status;
+            }
+            result = async { ghci.lock().await.restart().await } => {
+                result.wrap_err("Failed to restart ghci after unexpected exit")?;
+                return Ok(RetryResult::Restarted);
+            }
         }
     }
 }

--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -246,6 +246,10 @@ pub struct Ghci {
     /// trigger a shutdown of the entire program. This is bad if we're restarting `ghci` on
     /// purpose, so this channel helps us avoid that.
     restart_sender: mpsc::Sender<()>,
+    /// Sender for notifying [`run_ghci`][manager::run_ghci] when `ghci` exits unexpectedly.
+    /// Cloned into each new [`GhciProcess`] on construction; kept alive here so the channel is
+    /// never closed while this session is live.
+    exited_sender: mpsc::Sender<ExitStatus>,
     /// Writer for `ghcid`-compatible output, useful for editor integration for diagnostics.
     error_log: ErrorLog,
     /// Classifies file events into reload actions based on glob patterns.
@@ -280,7 +284,11 @@ impl Ghci {
     /// This starts a number of asynchronous tasks to manage the `ghci` session's input and output
     /// streams.
     #[instrument(skip_all, level = "debug", name = "ghci")]
-    pub async fn new(mut shutdown: ShutdownHandle, opts: GhciOpts) -> miette::Result<Self> {
+    pub async fn new(
+        mut shutdown: ShutdownHandle,
+        opts: GhciOpts,
+        exited_sender: mpsc::Sender<ExitStatus>,
+    ) -> miette::Result<Self> {
         let mut command_handles = Vec::new();
         {
             let span = tracing::debug_span!("before_startup_shell");
@@ -363,6 +371,7 @@ impl Ghci {
                     shutdown,
                     restart_receiver,
                     process_group_id,
+                    exited_sender: exited_sender.clone(),
                 }
                 .run(group)
             })
@@ -379,6 +388,7 @@ impl Ghci {
             stdin,
             stdout,
             restart_sender,
+            exited_sender,
             error_log,
             classifier,
             targets: Default::default(),
@@ -506,7 +516,12 @@ impl Ghci {
         self.run_hooks(LifecycleEvent::Restart(hooks::When::Before), &mut log)
             .await?;
         self.stop().await?;
-        let new = Self::new(self.shutdown.clone(), self.opts.clone()).await?;
+        let new = Self::new(
+            self.shutdown.clone(),
+            self.opts.clone(),
+            self.exited_sender.clone(),
+        )
+        .await?;
         let _ = std::mem::replace(self, new);
         self.initialize(
             &mut log,

--- a/src/ghci/process.rs
+++ b/src/ghci/process.rs
@@ -20,6 +20,11 @@ pub struct GhciProcess {
     /// This is used for the graceful shutdown implementation and for routine `ghci` session
     /// restarts.
     pub restart_receiver: mpsc::Receiver<()>,
+    /// Notifies [`run_ghci`][crate::ghci::manager::run_ghci] when `ghci` exits unexpectedly so
+    /// it can restart the session. Only sent on the unexpected-exit path; intentional restarts
+    /// go through [`restart_receiver`][GhciProcess::restart_receiver] instead and do not send
+    /// here.
+    pub exited_sender: mpsc::Sender<ExitStatus>,
 }
 
 impl GhciProcess {
@@ -37,8 +42,10 @@ impl GhciProcess {
                 self.stop(wait).await?;
             }
             result = &mut wait => {
-                self.exited(result.into_diagnostic()?).await;
-                let _ = self.shutdown.request_shutdown();
+                tracing::debug!(?result, "ghci exited");
+                let status = result.into_diagnostic()?;
+                self.exited(status).await;
+                let _ = self.exited_sender.send(status).await;
             }
         }
         Ok(())

--- a/src/incremental_reader.rs
+++ b/src/incremental_reader.rs
@@ -97,7 +97,12 @@ where
 
         match self.reader.read(opts.buffer).await {
             Ok(0) => {
-                // EOF
+                // EOF — the process closed its stdout. Yield to allow other tasks
+                // (e.g., GhciProcess reporting the exit) to run before we loop again.
+                // This prevents a busy-loop and ensures that a tokio::select! containing
+                // this future will check its other arms (like exited_receiver.recv()) on
+                // the next poll.
+                tokio::task::yield_now().await;
                 Ok(None)
             }
             Ok(n) => {

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -3,7 +3,9 @@ use nix::sys::signal::Signal;
 use nix::unistd::Pid;
 use test_harness::test;
 use test_harness::BaseMatcher;
+use test_harness::Fs;
 use test_harness::GhciWatch;
+use test_harness::GhciWatchBuilder;
 use test_harness::JsonValue;
 
 /// Test that `ghciwatch` can gracefully shutdown on Ctrl-C.
@@ -29,10 +31,23 @@ async fn can_shutdown_gracefully() {
     assert!(status.success(), "ghciwatch exits successfully");
 }
 
-/// Test that `ghciwatch` can gracefully shutdown when the `ghci` process is unexpectedly killed.
+fn extract_pid(event: &test_harness::Event) -> i32 {
+    match event.fields.get("pid").unwrap() {
+        JsonValue::Number(pid) => pid,
+        value => panic!("pid field has wrong type: {value:?}"),
+    }
+    .as_i64()
+    .expect("pid is i64")
+    .try_into()
+    .expect("pid is i32")
+}
+
+/// Test that when the `ghci` process is unexpectedly killed, `ghciwatch` waits for a file change
+/// and then restarts the session rather than shutting down.
 #[test]
-async fn can_shutdown_gracefully_when_ghci_killed() {
-    let mut session = GhciWatch::new("tests/data/simple")
+async fn restarts_after_ghci_killed() {
+    let mut session = GhciWatchBuilder::new("tests/data/simple")
+        .start()
         .await
         .expect("ghciwatch starts");
 
@@ -40,16 +55,51 @@ async fn can_shutdown_gracefully_when_ghci_killed() {
         .wait_for_log(BaseMatcher::message("^Started ghci$"))
         .await
         .expect("ghciwatch starts ghci");
-    let pid: i32 = match event.fields.get("pid").unwrap() {
-        JsonValue::Number(pid) => pid,
-        value => {
-            panic!("pid field has wrong type: {value:?}");
-        }
-    }
-    .as_i64()
-    .expect("pid is i64")
-    .try_into()
-    .expect("pid is i32");
+    let pid = extract_pid(&event);
+
+    session
+        .wait_until_ready()
+        .await
+        .expect("ghciwatch loads ghci");
+
+    signal::kill(Pid::from_raw(pid), Signal::SIGKILL).expect("Failed to kill ghci");
+
+    // ghciwatch should detect the exit and wait for a file change.
+    session
+        .wait_for_log("ghci exited unexpectedly")
+        .await
+        .expect("ghciwatch detects unexpected ghci exit");
+
+    // A file change triggers the restart.
+    session
+        .fs()
+        .touch(session.path("src/MyLib.hs"))
+        .await
+        .expect("can touch source file");
+
+    // ghciwatch should restart ghci and finish loading. After an unexpected exit, ghciwatch logs
+    // "Finished restarting in X.Xs" (not "Finished starting up"), so we match on the common
+    // suffix rather than ghci_started() which only matches "starting up".
+    session
+        .wait_for_log(BaseMatcher::message(r"Finished restarting in \d+\.\d+m?s$"))
+        .await
+        .expect("ghciwatch restarts ghci after unexpected exit");
+}
+
+/// Test that when ghci is killed, irrelevant file changes (non-Haskell, non-glob-matched) do not
+/// trigger a restart, but a relevant Haskell file change does.
+#[test]
+async fn does_not_restart_on_irrelevant_file_change() {
+    let mut session = GhciWatchBuilder::new("tests/data/simple")
+        .start()
+        .await
+        .expect("ghciwatch starts");
+
+    let event = session
+        .wait_for_log(BaseMatcher::message("^Started ghci$"))
+        .await
+        .expect("ghciwatch starts ghci");
+    let pid = extract_pid(&event);
 
     session
         .wait_until_ready()
@@ -59,12 +109,157 @@ async fn can_shutdown_gracefully_when_ghci_killed() {
     signal::kill(Pid::from_raw(pid), Signal::SIGKILL).expect("Failed to kill ghci");
 
     session
-        .wait_for_log("^ghci exited:")
+        .wait_for_log("ghci exited unexpectedly")
         .await
-        .expect("ghci exits");
-    session.wait_for_log("^Shutdown requested$").await.unwrap();
+        .expect("ghciwatch detects unexpected ghci exit");
+
+    // Touch an irrelevant file inside the watched `src/` directory. The watcher will send the
+    // event, but the classifier should skip it because it's not a Haskell source file and doesn't
+    // match any reload/restart globs.
     session
-        .wait_for_log("^All tasks completed successfully$")
+        .fs()
+        .touch(session.path("src/irrelevant.txt"))
         .await
-        .unwrap();
+        .expect("can touch irrelevant file");
+
+    session
+        .wait_for_log("File change not relevant to ghci; continuing to wait")
+        .await
+        .expect("ghciwatch skips irrelevant file change");
+
+    // Now touch a relevant Haskell file to trigger the actual restart.
+    session
+        .fs()
+        .touch(session.path("src/MyLib.hs"))
+        .await
+        .expect("can touch source file");
+
+    session
+        .wait_for_log(BaseMatcher::message(r"Finished restarting in \d+\.\d+m?s$"))
+        .await
+        .expect("ghciwatch restarts ghci after relevant file change");
+}
+
+/// Test that when ghci fails to start repeatedly (e.g. a dependency won't compile), ghciwatch
+/// keeps waiting for file changes and retrying rather than crashing after the first attempt.
+#[test]
+async fn handles_repeated_startup_failures() {
+    let mut session = GhciWatchBuilder::new("tests/data/with-dep")
+        .before_start(move |path| {
+            // A version of SimpleDep.hs with an unclosed string literal — cabal will refuse to build it.
+            async move {
+                Fs::new()
+                    .replace(
+                        path.join("simple-dep/src/SimpleDep.hs"),
+                        "\"depFunc\"",
+                        "\"depFunc",
+                    )
+                    .await
+            }
+        })
+        .start()
+        .await
+        .expect("ghciwatch starts");
+
+    // First startup fails because simple-dep won't compile.
+    session
+        .wait_for_log("ghci exited during startup")
+        .await
+        .expect("ghciwatch detects first startup failure");
+
+    // Touching a source file triggers the first restart attempt, which also fails.
+    session
+        .fs()
+        .touch(session.path("src/MyLib.hs"))
+        .await
+        .expect("can touch source file");
+
+    // The second failure confirms the retry loop re-enters rather than crashing.
+    session
+        .wait_for_log("ghci exited during startup")
+        .await
+        .expect("ghciwatch detects second startup failure");
+
+    // Fix the dependency, then trigger another restart.
+    session
+        .fs()
+        .replace(
+            session.path("simple-dep/src/SimpleDep.hs"),
+            "\"depFunc",
+            "\"depFunc\"",
+        )
+        .await
+        .expect("can fix simple-dep");
+    session
+        .fs()
+        .touch(session.path("src/MyLib.hs"))
+        .await
+        .expect("can touch source file");
+
+    // This restart should succeed.
+    session
+        .wait_for_log(BaseMatcher::message(r"Finished restarting in \d+\.\d+m?s$"))
+        .await
+        .expect("ghciwatch restarts ghci after dependency is fixed");
+}
+
+/// Test that when ghci exits unexpectedly during a dispatched reload/restart (not during startup),
+/// ghciwatch detects the exit and restarts on the next relevant file change.
+///
+/// This catches a bug where the dispatch `tokio::select!` did not poll `exited_receiver`, causing
+/// the dispatch task to hold the ghci Mutex forever and deadlocking the retry-restart loop.
+#[test]
+async fn handles_unexpected_exit_during_dispatch() {
+    let mut session = GhciWatchBuilder::new("tests/data/with-dep")
+        .with_args([
+            "--watch",
+            "simple-dep",
+            "--restart-glob",
+            "simple-dep/src/*.hs",
+        ])
+        .start()
+        .await
+        .expect("ghciwatch starts");
+
+    // Wait for successful initial startup.
+    session
+        .wait_until_ready()
+        .await
+        .expect("ghciwatch loads ghci");
+
+    // Introduce a syntax error in the dependency. Since it matches --restart-glob,
+    // this triggers a restart. The restart fails because cabal can't build the broken
+    // dependency, causing ghci to exit unexpectedly.
+    session
+        .fs()
+        .replace(
+            session.path("simple-dep/src/SimpleDep.hs"),
+            "\"depFunc\"",
+            "\"depFunc",
+        )
+        .await
+        .expect("can break simple-dep");
+
+    // ghciwatch should detect the unexpected exit (not "during startup").
+    session
+        .wait_for_log("ghci exited unexpectedly")
+        .await
+        .expect("ghciwatch detects unexpected exit during dispatch");
+
+    // Fix the syntax error. This also matches --restart-glob, so it triggers a restart attempt.
+    session
+        .fs()
+        .replace(
+            session.path("simple-dep/src/SimpleDep.hs"),
+            "\"depFunc",
+            "\"depFunc\"",
+        )
+        .await
+        .expect("can fix simple-dep");
+
+    // ghciwatch should restart successfully.
+    session
+        .wait_for_log(BaseMatcher::message(r"Finished restarting in \d+\.\d+m?s$"))
+        .await
+        .expect("ghciwatch restarts ghci after fixing the dependency");
 }


### PR DESCRIPTION
When you're running ghciwatch and code in your package fails to compile, ghciwatch tells you that a reload failed and waits for files to change to try compiling again (it even does this during the initial load/startup).

However, if the compilation error is in a _dependency_ of your package, in particular one listed in the `packages` field of your `cabal.project` (i.e. with its source code in your repository), ghciwatch just says that startup failed and quits out.

Well no more!! Now ghciwatch will wait for files to change; when they do, it will attempt to start ghci again. Nice for multi-package projects!

Note that you still need to tell ghciwatch _which_ files are worth restarting over. If your package depends on a dependency `my-dependency`, you probably want to add something like this to your ghciwatch invocation:

```
ghciwatch \
    --watch my-dependency \
    --restart-glob 'my-dependency/src/**/*.hs' \
    --restart-glob 'my-dependency/my-dependency.cabal'
```

- [x] Updated the user manual in `docs/`.
- [x] Added integration / regression tests in `tests/`.
