### PR TITLE
CARDI-737 Skip before-restart hooks after startup failures

### DIFF
--- a/src/ghci/manager.rs
+++ b/src/ghci/manager.rs
@@ -123,7 +123,7 @@ pub async fn run_ghci(
                 Some(new_status) = exited_receiver.recv() => {
                     status = new_status;
                 }
-                result = ghci.restart() => {
+                result = ghci.startup_restart() => {
                     result.wrap_err("Failed to restart ghci after startup failure")?;
                     break;
                 }

--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -508,6 +508,22 @@ impl Ghci {
         Ok(())
     }
 
+    /// Restart the `ghci` session without triggering restart hooks.
+    ///
+    /// This is meant to be used when starting the `ghci` session itself fails; in this case, we
+    /// don't have a prompt to write (e.g.) before-restart GHCi command hooks into, and we aren't
+    /// really "restarting" a session so much as starting it again. That is, this method avoids
+    /// "broken pipe" errors with `--before-restart-ghci` hooks.
+    #[instrument(skip_all, level = "debug")]
+    async fn startup_restart(&mut self) -> miette::Result<()> {
+        let mut log = CompilationLog::default();
+
+        self.restart_inner(&mut log, [LifecycleEvent::Startup(hooks::When::After)])
+            .await?;
+
+        Ok(())
+    }
+
     /// Restart the `ghci` session.
     #[instrument(skip_all, level = "debug")]
     async fn restart(&mut self) -> miette::Result<()> {
@@ -515,6 +531,24 @@ impl Ghci {
 
         self.run_hooks(LifecycleEvent::Restart(hooks::When::Before), &mut log)
             .await?;
+        self.restart_inner(
+            &mut log,
+            [
+                LifecycleEvent::Startup(hooks::When::After),
+                LifecycleEvent::Restart(hooks::When::After),
+            ],
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[instrument(skip_all, level = "debug")]
+    async fn restart_inner<const N: usize>(
+        &mut self,
+        log: &mut CompilationLog,
+        events: [LifecycleEvent; N],
+    ) -> miette::Result<()> {
         self.stop().await?;
         let new = Self::new(
             self.shutdown.clone(),
@@ -523,14 +557,7 @@ impl Ghci {
         )
         .await?;
         let _ = std::mem::replace(self, new);
-        self.initialize(
-            &mut log,
-            [
-                LifecycleEvent::Startup(hooks::When::After),
-                LifecycleEvent::Restart(hooks::When::After),
-            ],
-        )
-        .await?;
+        self.initialize(log, events).await?;
 
         Ok(())
     }

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -198,9 +198,52 @@ async fn handles_repeated_startup_failures() {
 
     // This restart should succeed.
     session
-        .wait_for_log(BaseMatcher::message(r"Finished restarting in \d+\.\d+m?s$"))
+        .wait_for_log(BaseMatcher::message(
+            r"Finished starting up in \d+\.\d+m?s$",
+        ))
         .await
         .expect("ghciwatch restarts ghci after dependency is fixed");
+}
+
+/// Check that startup failures are handled correctly with `--before-restart-ghci` hooks.
+#[test]
+async fn handles_repeated_startup_failures_before_restart_ghci_hook() {
+    let mut session = GhciWatchBuilder::new("tests/data/with-dep")
+        .before_start(move |path| {
+            // A version of SimpleDep.hs with an unclosed string literal — cabal will refuse to build it.
+            async move {
+                Fs::new()
+                    .replace(
+                        path.join("simple-dep/src/SimpleDep.hs"),
+                        "\"depFunc\"",
+                        "\"depFunc",
+                    )
+                    .await
+            }
+        })
+        .with_args(["--before-restart-ghci", "putStrLn \"hello\""])
+        .start()
+        .await
+        .expect("ghciwatch starts");
+
+    // First startup fails because simple-dep won't compile.
+    session
+        .wait_for_log("ghci exited during startup")
+        .await
+        .expect("ghciwatch detects first startup failure");
+
+    // Touching a source file triggers the first restart attempt, which also fails.
+    session
+        .fs()
+        .touch(session.path("src/MyLib.hs"))
+        .await
+        .expect("can touch source file");
+
+    // The second failure confirms the retry loop re-enters rather than crashing.
+    session
+        .wait_for_log("ghci exited during startup")
+        .await
+        .expect("ghciwatch detects second startup failure");
 }
 
 /// Test that when ghci exits unexpectedly during a dispatched reload/restart (not during startup),


### PR DESCRIPTION
With #403, if a `--before-restart-ghci` hook was provided, we would attempt to write the hook to the `ghci` stdin handle after startup failures, which would fail because the stdin handle has been closed, causing ghciwatch to error out.