### PR TITLE
Use `$TIMEOUT_MULT` for tests, not retries

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -17,7 +17,9 @@ fail-fast = false
 # `notify`. Even with sleeps before writing and poll-based notifications,
 # sometimes `notify` misses events (this is rare, maybe 1 in 50 test runs).
 # Retry tests if they fail in CI to mitigate this.
-retries = 3
+#
+# See also the `$TIMEOUT_MULT` environment variable.
+retries = 1
 
 [[profile.ci.overrides]]
 # `kind(test)` means integration tests in the `../tests/` directory.

--- a/nix/packages/ghciwatch.nix
+++ b/nix/packages/ghciwatch.nix
@@ -229,6 +229,9 @@
       NEXTEST_PROFILE = "ci";
       NEXTEST_HIDE_PROGRESS_BAR = "true";
 
+      # See `../../tests/README.md`.
+      TIMEOUT_MULT = "12";
+
       # Provide GHC versions to use to the integration test suite.
       inherit GHC_VERSIONS;
     };

--- a/test-harness/src/ghciwatch.rs
+++ b/test-harness/src/ghciwatch.rs
@@ -17,6 +17,7 @@ use tap::Conv;
 use tokio::process::Command;
 
 use crate::matcher::Matcher;
+use crate::timeout_mult::timeout_mult;
 use crate::tracing_reader::TracingReader;
 use crate::BaseMatcher;
 use crate::Checkpoint;
@@ -55,8 +56,9 @@ impl GhciWatchBuilder {
             cabal_args: Default::default(),
             cabal_target: "my-simple-package".into(),
             before_start: None,
-            default_timeout: Duration::from_secs(10),
-            startup_timeout: Duration::from_secs(60),
+            // Note: These will be scaled by `timeout_mult` later.
+            default_timeout: Duration::from_secs(7),
+            startup_timeout: Duration::from_secs(10),
             log_filters: Default::default(),
         }
     }
@@ -119,7 +121,7 @@ impl GhciWatchBuilder {
     /// Set the default timeout to wait for log messages in [`GhciWatch::wait_for_log`],
     /// [`GhciWatch::assert_logged_or_wait`], and similar.
     ///
-    /// The timeout defaults to 10 seconds.
+    /// This is multiplied with [`timeout_mult`].
     pub fn with_default_timeout(mut self, default_timeout: Duration) -> Self {
         self.default_timeout = default_timeout;
         self
@@ -128,7 +130,7 @@ impl GhciWatchBuilder {
     /// Set the default timeout to wait for `ghci` to start up in
     /// [`GhciWatch::wait_until_started`] and [`GhciWatch::wait_until_ready`].
     ///
-    /// The timeout defaults to 60 seconds.
+    /// This is multiplied with [`timeout_mult`].
     pub fn with_startup_timeout(mut self, startup_timeout: Duration) -> Self {
         self.startup_timeout = startup_timeout;
         self
@@ -454,6 +456,8 @@ impl GhciWatch {
         checkpoints: Option<C>,
         timeout_duration: Duration,
     ) -> miette::Result<Event> {
+        let timeout_duration = timeout_mult(timeout_duration)?;
+
         let mut matcher = matcher.into_matcher()?;
 
         // First check if it was logged in `checkpoints`.

--- a/test-harness/src/lib.rs
+++ b/test-harness/src/lib.rs
@@ -40,3 +40,7 @@ pub use ghc_version::GhcVersion;
 mod checkpoint;
 pub use checkpoint::Checkpoint;
 pub use checkpoint::CheckpointIndex;
+
+mod timeout_mult;
+pub use timeout_mult::get_timeout_mult;
+pub use timeout_mult::timeout_mult;

--- a/test-harness/src/timeout_mult.rs
+++ b/test-harness/src/timeout_mult.rs
@@ -1,0 +1,43 @@
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use miette::miette;
+use miette::Context;
+use miette::IntoDiagnostic;
+
+const TIMEOUT_MULT_VAR: &str = "TIMEOUT_MULT";
+const DEFAULT_TIMEOUT_MULT: f64 = 1.0;
+
+static TIMEOUT_MULT: OnceLock<miette::Result<f64>> = OnceLock::new();
+
+/// Multiply a [`Duration`] by the `$TIMEOUT_MULT`.
+///
+/// See: [`get_timeout_mult`].
+pub fn timeout_mult(duration: Duration) -> miette::Result<Duration> {
+    match get_timeout_mult() {
+        Ok(mult) => Ok(duration.mul_f64(*mult)),
+        // lol
+        Err(err) => Err(miette!("{err}")),
+    }
+}
+
+/// Get the `$TIMEOUT_MULT` environment variable.
+///
+/// This is a multiplier for all test timeout durations; it's used to make tests more reliable in CI
+/// and under load.
+pub fn get_timeout_mult() -> &'static miette::Result<f64> {
+    TIMEOUT_MULT.get_or_init(get_timeout_mult_inner)
+}
+
+fn get_timeout_mult_inner() -> miette::Result<f64> {
+    match std::env::var(TIMEOUT_MULT_VAR) {
+        Ok(raw) => raw
+            .parse()
+            .into_diagnostic()
+            .wrap_err("Failed to parse `$TIMEOUT_MULT`"),
+        Err(std::env::VarError::NotPresent) => Ok(DEFAULT_TIMEOUT_MULT),
+        Err(err) => Err(err)
+            .into_diagnostic()
+            .wrap_err("Failed to get `$TIMEOUT_MULT`"),
+    }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -45,3 +45,19 @@ Note that this only applies to _failing_ tests. If we're willing to wait 10
 seconds for a log message, but the message appears after 1 second, we'll
 consume that log message and move on. Longer timeouts only make _failing_ tests
 slower.
+
+
+### `$TIMEOUT_MULT`
+
+The `$TIMEOUT_MULT` environment variable is a way to adjust the timeouts
+dynamically; our CI runners tend to be slower than our developer workstations,
+for example.
+
+The more tests you'd like to run at once, the slower they get. The default
+timeouts are fine when I'm running tests at `-j 16`, but at `-j 64` they fail
+frequently, just because all the underlying operations have a harder time
+contending for resources.
+
+Therefore, you can run something like `TIMEOUT_MULT=2 cargo nextest run
+--test-threads 64` to give your tests a little more wiggle room without
+changing hard-coded defaults or resorting to retries.


### PR DESCRIPTION
This adds a new `$TIMEOUT_MULT` environment variable for tests, which acts as a numeric multiplier for all test timeouts, which can be used on CI or slower developer workstations in order to accommodate slower execution of the Haskell compilation that underlies ghciwatch integration tests.
