### PR TITLE
tests: Fix startup timeouts

### DIFF
--- a/test-harness/src/ghciwatch.rs
+++ b/test-harness/src/ghciwatch.rs
@@ -237,7 +237,7 @@ pub struct GhciWatch {
     /// The default timeout for waiting for log messages.
     default_timeout: Duration,
     /// The timeout for waiting for `ghci to finish starting up.
-    startup_timeout: Duration,
+    pub startup_timeout: Duration,
     /// Filesystem helpers.
     fs: Fs,
     /// Data for this particular `ghciwatch` run. This changes when
@@ -362,7 +362,7 @@ impl GhciWatch {
 
     /// Get the current [`Checkpoint`].
     ///
-    /// Events read by [`GhciWatch::wait_for_log_with_timeout`] and friends will add events to
+    /// Events read by [`GhciWatch::wait_for_log`] and friends will add events to
     /// this checkpoint.
     pub fn current_checkpoint(&self) -> Checkpoint {
         Checkpoint(self.events.len() - 1)
@@ -450,7 +450,7 @@ impl GhciWatch {
     /// events.
     ///
     /// Errors if waiting for the event takes longer than the given `timeout`.
-    pub async fn wait_for_log_with_timeout<M: IntoMatcher, C: CheckpointIndex>(
+    pub async fn wait_for_log_with_checkpoint_and_timeout<M: IntoMatcher, C: CheckpointIndex>(
         &mut self,
         matcher: M,
         checkpoints: Option<C>,
@@ -487,6 +487,16 @@ impl GhciWatch {
         }
     }
 
+    /// Wait until a matching log event is found with the given `timeout_duration`.
+    pub async fn wait_for_log_with_timeout<M: IntoMatcher>(
+        &mut self,
+        matcher: M,
+        timeout_duration: Duration,
+    ) -> miette::Result<Event> {
+        self.wait_for_log_with_checkpoint_and_timeout(matcher, None::<Checkpoint>, timeout_duration)
+            .await
+    }
+
     /// Assert that a message matching `matcher` has been logged in the given [`Checkpoint`]s or
     /// wait for the `default_timeout` for a matching message to be logged.
     pub async fn assert_logged_in_checkpoint_or_wait(
@@ -494,8 +504,12 @@ impl GhciWatch {
         checkpoints: impl CheckpointIndex,
         matcher: impl IntoMatcher,
     ) -> miette::Result<Event> {
-        self.wait_for_log_with_timeout(matcher, Some(checkpoints), self.default_timeout)
-            .await
+        self.wait_for_log_with_checkpoint_and_timeout(
+            matcher,
+            Some(checkpoints),
+            self.default_timeout,
+        )
+        .await
     }
 
     /// Assert that a message matching `matcher` has been logged in the most recent [`Checkpoint`]
@@ -504,7 +518,7 @@ impl GhciWatch {
         &mut self,
         matcher: impl IntoMatcher,
     ) -> miette::Result<Event> {
-        self.wait_for_log_with_timeout(
+        self.wait_for_log_with_checkpoint_and_timeout(
             matcher,
             Some(self.current_checkpoint()),
             self.default_timeout,
@@ -514,7 +528,7 @@ impl GhciWatch {
 
     /// Wait until a matching log event is found with the `default_timeout`.
     pub async fn wait_for_log(&mut self, matcher: impl IntoMatcher) -> miette::Result<Event> {
-        self.wait_for_log_with_timeout(matcher, None::<Checkpoint>, self.default_timeout)
+        self.wait_for_log_with_timeout(matcher, self.default_timeout)
             .await
     }
 
@@ -523,7 +537,7 @@ impl GhciWatch {
     /// Returns immediately if `ghciwatch` has already completed its initial load in the current
     /// checkpoint.
     pub async fn wait_until_started(&mut self) -> miette::Result<()> {
-        self.wait_for_log_with_timeout(
+        self.wait_for_log_with_checkpoint_and_timeout(
             BaseMatcher::ghci_started(),
             Some(self.current_checkpoint()),
             self.startup_timeout,
@@ -538,7 +552,7 @@ impl GhciWatch {
     /// Returns immediately if `ghciwatch` has already become ready to receive file events in the
     /// current checkpoint.
     pub async fn wait_until_watcher_started(&mut self) -> miette::Result<()> {
-        self.wait_for_log_with_timeout(
+        self.wait_for_log_with_checkpoint_and_timeout(
             BaseMatcher::watcher_started(),
             Some(self.current_checkpoint()),
             self.default_timeout,
@@ -553,7 +567,7 @@ impl GhciWatch {
     /// Returns immediately if `ghciwatch` has already completed its inital load and become ready to
     /// receive file events in the current checkpoint.
     pub async fn wait_until_ready(&mut self) -> miette::Result<()> {
-        self.wait_for_log_with_timeout(
+        self.wait_for_log_with_checkpoint_and_timeout(
             BaseMatcher::ghci_started().and(BaseMatcher::watcher_started()),
             Some(self.current_checkpoint()),
             self.startup_timeout,

--- a/tests/experimental_features.rs
+++ b/tests/experimental_features.rs
@@ -25,8 +25,9 @@ async fn experimental_features_emits_warning() {
         .expect("ghciwatch starts");
 
     session
-        .wait_for_log(
+        .wait_for_log_with_timeout(
             "`--experimental-features` may contain bugs or change drastically in future releases.",
+            session.startup_timeout,
         )
         .await
         .unwrap();

--- a/tests/failed_modules.rs
+++ b/tests/failed_modules.rs
@@ -19,8 +19,11 @@ async fn can_start_with_failed_modules() {
         .expect("ghciwatch starts");
     let module_path = session.path(module_path);
 
+    // Note: `session.wait_until_ready()` has a longer timeout than the default (the
+    // `session.startup_timeout`), so this assert will fail more frequently unless we take care to
+    // use a custom timeout.
     session
-        .wait_for_log("Compilation failed")
+        .wait_for_log_with_timeout("Compilation failed", session.startup_timeout)
         .await
         .expect("ghciwatch fails to load with errors");
 

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -116,34 +116,46 @@ async fn can_run_hooks() {
     ghci_hook(&mut session, "after-restart", "2").await;
 }
 
+fn hook_timeout(session: &GhciWatch, hook: &str) -> Duration {
+    if hook.ends_with("-startup") || hook.ends_with("-restart") {
+        session.startup_timeout
+    } else {
+        Duration::from_secs(10)
+    }
+}
+
 async fn ghci_hook(session: &mut GhciWatch, hook: &str, index: &str) {
+    let timeout = hook_timeout(session, hook);
     session
-        .wait_for_log(
+        .wait_for_log_with_timeout(
             BaseMatcher::message(&format!("Running {hook} command"))
                 .with_field("command", &format!("putStrLn \"{hook}-{index}\"")),
+            timeout,
         )
         .await
         .unwrap();
     session
-        .wait_for_log(
+        .wait_for_log_with_timeout(
             BaseMatcher::message("Read line").with_field("line", &format!("^{hook}-{index}$")),
+            timeout,
         )
         .await
         .unwrap();
 }
 
 async fn shell_hook(session: &mut GhciWatch, hook: &str, index: &str) {
-    let wait_duration = Duration::from_secs(10);
+    let timeout = hook_timeout(session, hook);
     session
-        .wait_for_log(
+        .wait_for_log_with_timeout(
             BaseMatcher::message(&format!("Running {hook} command"))
                 .with_field("command", &format!("touch {hook}-{index}")),
+            timeout,
         )
         .await
         .unwrap();
     session
         .fs()
-        .wait_for_path(wait_duration, &session.path(format!("{hook}-{index}")))
+        .wait_for_path(timeout, &session.path(format!("{hook}-{index}")))
         .await
         .unwrap();
 }
@@ -180,16 +192,18 @@ async fn hooks_can_observe_error_log() {
         .expect("ghciwatch starts");
 
     session
-        .wait_for_log(
+        .wait_for_log_with_timeout(
             BaseMatcher::message("Running after-startup command")
                 .with_field("command", &regex::escape(&after_startup)),
+            session.startup_timeout,
         )
         .await
         .unwrap();
     session
-        .wait_for_log(
+        .wait_for_log_with_timeout(
             BaseMatcher::message("grep finished successfully")
                 .in_spans([SpanMatcher::new("run_hooks").with_field("event", "after-startup")]),
+            session.startup_timeout,
         )
         .await
         .unwrap();

--- a/tests/remove.rs
+++ b/tests/remove.rs
@@ -39,7 +39,7 @@ async fn can_remove_multiple_modules_at_once() {
         .expect("ghciwatch starts");
 
     session
-        .wait_for_log(
+        .wait_for_log_with_timeout(
             BaseMatcher::message("Read line")
                 .in_spans(["refresh_targets"])
                 .with_field("line", "MyLib")
@@ -48,6 +48,7 @@ async fn can_remove_multiple_modules_at_once() {
                         .in_spans(["refresh_targets"])
                         .with_field("line", "MyModule"),
                 ),
+            session.startup_timeout,
         )
         .await
         .expect("2 modules are loaded");

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -52,7 +52,10 @@ async fn restarts_after_ghci_killed() {
         .expect("ghciwatch starts");
 
     let event = session
-        .wait_for_log(BaseMatcher::message("^Started ghci$"))
+        .wait_for_log_with_timeout(
+            BaseMatcher::message("^Started ghci$"),
+            session.startup_timeout,
+        )
         .await
         .expect("ghciwatch starts ghci");
     let pid = extract_pid(&event);
@@ -81,7 +84,10 @@ async fn restarts_after_ghci_killed() {
     // "Finished restarting in X.Xs" (not "Finished starting up"), so we match on the common
     // suffix rather than ghci_started() which only matches "starting up".
     session
-        .wait_for_log(BaseMatcher::message(r"Finished restarting in \d+\.\d+m?s$"))
+        .wait_for_log_with_timeout(
+            BaseMatcher::message(r"Finished restarting in \d+\.\d+m?s$"),
+            session.startup_timeout,
+        )
         .await
         .expect("ghciwatch restarts ghci after unexpected exit");
 }
@@ -96,7 +102,10 @@ async fn does_not_restart_on_irrelevant_file_change() {
         .expect("ghciwatch starts");
 
     let event = session
-        .wait_for_log(BaseMatcher::message("^Started ghci$"))
+        .wait_for_log_with_timeout(
+            BaseMatcher::message("^Started ghci$"),
+            session.startup_timeout,
+        )
         .await
         .expect("ghciwatch starts ghci");
     let pid = extract_pid(&event);
@@ -135,7 +144,10 @@ async fn does_not_restart_on_irrelevant_file_change() {
         .expect("can touch source file");
 
     session
-        .wait_for_log(BaseMatcher::message(r"Finished restarting in \d+\.\d+m?s$"))
+        .wait_for_log_with_timeout(
+            BaseMatcher::message(r"Finished restarting in \d+\.\d+m?s$"),
+            session.startup_timeout,
+        )
         .await
         .expect("ghciwatch restarts ghci after relevant file change");
 }
@@ -163,7 +175,7 @@ async fn handles_repeated_startup_failures() {
 
     // First startup fails because simple-dep won't compile.
     session
-        .wait_for_log("ghci exited during startup")
+        .wait_for_log_with_timeout("ghci exited during startup", session.startup_timeout)
         .await
         .expect("ghciwatch detects first startup failure");
 
@@ -176,7 +188,7 @@ async fn handles_repeated_startup_failures() {
 
     // The second failure confirms the retry loop re-enters rather than crashing.
     session
-        .wait_for_log("ghci exited during startup")
+        .wait_for_log_with_timeout("ghci exited during startup", session.startup_timeout)
         .await
         .expect("ghciwatch detects second startup failure");
 
@@ -198,9 +210,10 @@ async fn handles_repeated_startup_failures() {
 
     // This restart should succeed.
     session
-        .wait_for_log(BaseMatcher::message(
-            r"Finished starting up in \d+\.\d+m?s$",
-        ))
+        .wait_for_log_with_timeout(
+            BaseMatcher::message(r"Finished starting up in \d+\.\d+m?s$"),
+            session.startup_timeout,
+        )
         .await
         .expect("ghciwatch restarts ghci after dependency is fixed");
 }
@@ -228,7 +241,7 @@ async fn handles_repeated_startup_failures_before_restart_ghci_hook() {
 
     // First startup fails because simple-dep won't compile.
     session
-        .wait_for_log("ghci exited during startup")
+        .wait_for_log_with_timeout("ghci exited during startup", session.startup_timeout)
         .await
         .expect("ghciwatch detects first startup failure");
 
@@ -241,7 +254,7 @@ async fn handles_repeated_startup_failures_before_restart_ghci_hook() {
 
     // The second failure confirms the retry loop re-enters rather than crashing.
     session
-        .wait_for_log("ghci exited during startup")
+        .wait_for_log_with_timeout("ghci exited during startup", session.startup_timeout)
         .await
         .expect("ghciwatch detects second startup failure");
 }
@@ -302,7 +315,10 @@ async fn handles_unexpected_exit_during_dispatch() {
 
     // ghciwatch should restart successfully.
     session
-        .wait_for_log(BaseMatcher::message(r"Finished restarting in \d+\.\d+m?s$"))
+        .wait_for_log_with_timeout(
+            BaseMatcher::message(r"Finished restarting in \d+\.\d+m?s$"),
+            session.startup_timeout,
+        )
         .await
         .expect("ghciwatch restarts ghci after fixing the dependency");
 }


### PR DESCRIPTION
I noticed the `failed_modules` test was flakier (relatively) than the other tests. I figured out why: it was using a too-short timeout! Turns out a couple other tests had the same bug.