### PR TITLE
CARDI-743 Error log: Write "still compiling" message

### DIFF
--- a/src/ghci/error_log.rs
+++ b/src/ghci/error_log.rs
@@ -1,4 +1,5 @@
 use camino::Utf8PathBuf;
+use miette::Context;
 use miette::IntoDiagnostic;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
@@ -8,6 +9,13 @@ use tracing::instrument;
 use super::parse::CompilationResult;
 use super::parse::ModulesLoaded;
 use super::CompilationLog;
+
+/// Message we write to the error log to indicate that ghciwatch is currently reloading or
+/// restarting.
+///
+/// This helps LLM Agents figure out that the reason they're not seeing any errors is because
+/// compilation hasn't finished yet.
+const STILL_COMPILING: &str = "[ghciwatch is still compiling]";
 
 /// Error log writer.
 ///
@@ -21,6 +29,24 @@ impl ErrorLog {
     /// Construct a new error log writer for the given path.
     pub fn new(path: Option<Utf8PathBuf>) -> Self {
         Self { path }
+    }
+
+    /// Write the "still compiling" message to the error log before a reload or restart.
+    pub async fn write_still_compiling(&self) -> miette::Result<()> {
+        let path = match &self.path {
+            Some(path) => path,
+            None => {
+                tracing::debug!("No error log path, not writing");
+                return Ok(());
+            }
+        };
+
+        tokio::fs::write(path, STILL_COMPILING)
+            .await
+            .into_diagnostic()
+            .wrap_err_with(|| "Failed to write error log: {path}")?;
+
+        Ok(())
     }
 
     /// Write the error log, if any, with the given compilation summary and diagnostic messages.

--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -412,6 +412,8 @@ impl Ghci {
     ) -> miette::Result<()> {
         let start_instant = Instant::now();
 
+        self.error_log.write_still_compiling().await?;
+
         // Wait for the stdout job to start up.
         self.stdout.initialize(log).await?;
 
@@ -450,6 +452,7 @@ impl Ghci {
 
         if actions.needs_restart() {
             self.opts.clear();
+            self.error_log.write_still_compiling().await?;
             tracing::info!(
                 "Restarting ghci:\n{}",
                 format_bulleted_list(&actions.needs_restart)
@@ -464,6 +467,7 @@ impl Ghci {
 
         if actions.needs_modify() {
             self.opts.clear();
+            self.error_log.write_still_compiling().await?;
             self.run_hooks(LifecycleEvent::Reload(hooks::When::Before), &mut log)
                 .await?;
         }


### PR DESCRIPTION
At startup and before reloads and restarts, write `[ghciwatch is still compiling]` to the error log.

This helps LLM Agents figure out that the reason they're not seeing any errors is because compilation hasn't finished yet.
