### PR TITLE
CARDI-745 manager: Always do `startup_restart` when `ghci` exits

### DIFF
--- a/src/ghci/manager.rs
+++ b/src/ghci/manager.rs
@@ -371,7 +371,7 @@ enum RetryResult {
 enum RestartStrategy<'a> {
     /// ghci failed during first startup; use [`Ghci::startup_restart`].
     Startup(&'a mut Ghci),
-    /// ghci died at runtime; lock the [`Arc`] and call [`Ghci::restart`].
+    /// ghci died at runtime; lock the [`Arc`] and call [`Ghci::startup_restart`].
     Runtime(Arc<Mutex<Ghci>>),
 }
 
@@ -392,7 +392,7 @@ impl RestartStrategy<'_> {
             Self::Runtime(ghci) => ghci
                 .lock()
                 .await
-                .restart()
+                .startup_restart()
                 .await
                 .wrap_err("Failed to restart ghci after unexpected exit"),
         }

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -71,6 +71,7 @@ async fn restarts_after_ghci_killed() {
         .expect("ghciwatch detects unexpected ghci exit");
 
     // A file change triggers the restart.
+    session.clear_events();
     session
         .fs()
         .touch(session.path("src/MyLib.hs"))
@@ -81,7 +82,7 @@ async fn restarts_after_ghci_killed() {
     // "Finished restarting in X.Xs" (not "Finished starting up"), so we match on the common
     // suffix rather than ghci_started() which only matches "starting up".
     session
-        .wait_for_startup_log(BaseMatcher::message(r"Finished restarting in \d+\.\d+m?s$"))
+        .wait_for_startup_log(BaseMatcher::ghci_started())
         .await
         .expect("ghciwatch restarts ghci after unexpected exit");
 }
@@ -128,6 +129,7 @@ async fn does_not_restart_on_irrelevant_file_change() {
         .expect("ghciwatch skips irrelevant file change");
 
     // Now touch a relevant Haskell file to trigger the actual restart.
+    session.clear_events();
     session
         .fs()
         .touch(session.path("src/MyLib.hs"))
@@ -135,7 +137,7 @@ async fn does_not_restart_on_irrelevant_file_change() {
         .expect("can touch source file");
 
     session
-        .wait_for_startup_log(BaseMatcher::message(r"Finished restarting in \d+\.\d+m?s$"))
+        .wait_for_startup_log(BaseMatcher::ghci_started())
         .await
         .expect("ghciwatch restarts ghci after relevant file change");
 }
@@ -308,7 +310,7 @@ async fn handles_unexpected_exit_during_dispatch() {
 
     // ghciwatch should restart successfully.
     session
-        .wait_for_startup_log(BaseMatcher::message(r"Finished restarting in \d+\.\d+m?s$"))
+        .wait_for_startup_log(BaseMatcher::ghci_started())
         .await
         .expect("ghciwatch restarts ghci after fixing the dependency");
 }


### PR DESCRIPTION
If `ghci` exits, we can't run before-restart GHCi commands, because there's no `ghci` session to send them too, so the normal `.restart()` fails.

This fixes a bug with dependency compilation errors on startup.