### PR TITLE
`no_interrupt_reloads` -> `interrupt_reloads`

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -69,7 +69,7 @@ pub struct Opts {
     ///
     /// Depending on your workflow, `ghciwatch` may feel more responsive with this set.
     #[arg(long)]
-    pub no_interrupt_reloads: bool,
+    no_interrupt_reloads: bool,
 
     /// Enable experimental features. These features are unsupported and may change or be removed
     /// without notice.
@@ -228,6 +228,11 @@ pub struct LoggingOpts {
 }
 
 impl Opts {
+    /// Should reloads be interrupted with Ctrl-C when files change?
+    pub fn interrupt_reloads(&self) -> bool {
+        !self.no_interrupt_reloads
+    }
+
     /// Check whether a given experimental feature has been enabled.
     pub fn has_experimental_feature(&self, feature: ExperimentalFeature) -> bool {
         self.experimental_features.contains(&feature)

--- a/src/ghci/manager.rs
+++ b/src/ghci/manager.rs
@@ -60,7 +60,7 @@ pub async fn run_ghci(
     // This function is pretty tricky! We need to handle shutdowns at each stage, and the process
     // is a little different each time, so the `select!`s can't be consolidated.
 
-    let no_interrupt_reloads = opts.no_interrupt_reloads;
+    let interrupt_reloads = opts.interrupt_reloads;
     let classifier = opts.file_classifier()?;
     let (exited_sender, mut exited_receiver) = mpsc::channel::<ExitStatus>(1);
     let mut ghci = Ghci::new(handle.clone(), opts, exited_sender)
@@ -109,7 +109,7 @@ pub async fn run_ghci(
         receiver,
         exited_receiver,
         classifier,
-        no_interrupt_reloads,
+        interrupt_reloads,
     };
     manager.run().await
 }
@@ -159,7 +159,7 @@ struct GhciManager {
     receiver: mpsc::Receiver<WatcherEvent>,
     exited_receiver: mpsc::Receiver<ExitStatus>,
     classifier: FileClassifier,
-    no_interrupt_reloads: bool,
+    interrupt_reloads: bool,
 }
 
 /// Result of [`GhciManager::wait_for_event`].
@@ -262,7 +262,7 @@ impl GhciManager {
                 ref mut handle,
                 ref mut receiver,
                 ref mut exited_receiver,
-                no_interrupt_reloads,
+                interrupt_reloads,
                 ..
             } = *self;
             tokio::select! {
@@ -285,7 +285,7 @@ impl GhciManager {
                         ?new_event,
                         "Received ghci event from watcher while reloading"
                     );
-                    if !no_interrupt_reloads
+                    if interrupt_reloads
                         && should_interrupt(reload_receiver).await
                     {
                         // Merge the events together so we don't lose progress.

--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -117,7 +117,7 @@ pub struct GhciOpts {
     /// Reload the `ghci` session when paths matching these globs are changed.
     pub reload_globs: GlobMatcher,
     /// Determines whether we should interrupt a reload in progress or not.
-    pub no_interrupt_reloads: bool,
+    pub interrupt_reloads: bool,
     /// Where to write what `ghci` emits to `stdout`. Inherits parent's `stdout` by default.
     pub stdout_writer: GhciWriter,
     /// Where to write what `ghci` emits to `stderr`. Inherits parent's `stderr` by default.
@@ -198,7 +198,7 @@ impl GhciOpts {
                 hooks: opts.hooks.clone(),
                 restart_globs: opts.watch.restart_globs()?,
                 reload_globs: opts.watch.reload_globs()?,
-                no_interrupt_reloads: opts.no_interrupt_reloads,
+                interrupt_reloads: opts.interrupt_reloads(),
                 stdout_writer,
                 stderr_writer,
                 clear: opts.clear,


### PR DESCRIPTION
Fixes a double-negative in the code.