### PR TITLE
DUX-4368 manager: fix deadlock with reload interruption

### DIFF
--- a/src/ghci/manager.rs
+++ b/src/ghci/manager.rs
@@ -256,7 +256,14 @@ impl GhciManager {
             reload_sender,
         )));
 
-        let ghci_exited = {
+        // `should_interrupt` consumes the oneshot receiver, so we wrap it in an Option
+        // to track whether it's been used.
+        let mut reload_receiver = Some(reload_receiver);
+        // Events that arrive while we're waiting for a non-interruptible dispatch
+        // (e.g. a restart) to complete. Returned as `Interrupted` for retry.
+        let mut pending_event: Option<WatcherEvent> = None;
+
+        let ghci_exited = loop {
             let GhciManager {
                 ref ghci,
                 ref mut handle,
@@ -265,7 +272,7 @@ impl GhciManager {
                 interrupt_reloads,
                 ..
             } = *self;
-            tokio::select! {
+            break tokio::select! {
                 _ = handle.on_shutdown_requested() => {
                     // Cancel any in-progress reloads. This releases the lock so we don't
                     // block here.
@@ -285,30 +292,50 @@ impl GhciManager {
                         ?new_event,
                         "Received ghci event from watcher while reloading"
                     );
-                    if interrupt_reloads
-                        && should_interrupt(reload_receiver).await
-                    {
-                        // Merge the events together so we don't lose progress.
-                        event.merge(new_event);
 
-                        // Cancel the in-progress reload. This releases the `ghci` lock to
-                        // prevent a deadlock.
-                        task.abort();
+                    // Check if we should interrupt the in-progress reload. We can only
+                    // check once (the oneshot is consumed), and only for interruptible
+                    // reloads.
+                    if interrupt_reloads {
+                        if let Some(reload_receiver) = reload_receiver.take() {
+                            if should_interrupt(reload_receiver).await {
+                                // Merge everything: any previously accumulated events
+                                // plus the newest event.
+                                if let Some(pending_event) = pending_event.take() {
+                                    event.merge(pending_event);
+                                }
+                                event.merge(new_event);
 
-                        // Send a SIGINT to interrupt the reload.
-                        // NB: This may take a couple seconds to register.
-                        ghci.lock().await.send_sigint().await?;
+                                // Cancel the in-progress reload. This releases the
+                                // `ghci` lock to prevent a deadlock.
+                                task.abort();
 
-                        return Ok(HandleResult::Interrupted(event));
+                                // Send a SIGINT to interrupt the reload.
+                                // NB: This may take a couple seconds to register.
+                                ghci.lock().await.send_sigint().await?;
+
+                                return Ok(HandleResult::Interrupted(event));
+                            }
+                        }
                     }
-                    None
+
+                    // Either `interrupt_reloads` is `false`, the `reload_receiver` was already
+                    // consumed, or `should_interrupt` returned false. Accumulate the event
+                    // and keep waiting for the dispatch task to finish.
+                    match pending_event {
+                        Some(ref mut pending_event) => pending_event.merge(new_event),
+                        None => pending_event = Some(new_event),
+                    }
+
+                    // Loop around to make sure we keep waiting for the `task`.
+                    continue;
                 }
                 ret = &mut task => {
                     ret.into_diagnostic()??;
                     tracing::debug!("Finished dispatching ghci event");
                     None
                 }
-            }
+            };
         };
 
         // If ghci died during the dispatch, wait for a file change and restart.
@@ -318,6 +345,13 @@ impl GhciManager {
                 RetryResult::Shutdown => return Ok(HandleResult::Shutdown),
             }
         }
+
+        // If events arrived while the dispatch was running (but we chose not to
+        // interrupt), return them for retry on the next iteration.
+        if let Some(pending_event) = pending_event {
+            return Ok(HandleResult::Interrupted(pending_event));
+        }
+
         Ok(HandleResult::Done)
     }
 


### PR DESCRIPTION
Here's Claude's explanation:

> # Reload-interrupt deadlock in `handle_event`
>
> ## Summary
>
> When reload interruption is enabled (the default), ghciwatch can permanently
> stop responding to file events. The root cause is that `handle_event` can
> return while a dispatch task is still running and holding the
> `Arc<Mutex<Ghci>>`, creating a "detached" task that blocks all future
> operations on the mutex.
>
> Disabling interruption with `--no-interrupt-reloads` avoids the bug because
> the code path that detaches the task is never reached.
>
> ## Background
>
> `handle_event` spawns a `dispatch` task that acquires `Arc<Mutex<Ghci>>` and
> calls `Ghci::reload()`. While the task runs, a `tokio::select!` monitors
> four channels:
>
> 1. **Shutdown requested** -- abort the task, stop ghci, return.
> 2. **ghci exited** (`exited_receiver`) -- abort the task, restart ghci.
> 3. **New file event** (`receiver`) -- decide whether to interrupt the reload.
> 4. **Task completed** -- the dispatch finished normally.
>
> When a new file event arrives (arm 3), the code calls
> `should_interrupt(reload_receiver).await` to check whether the in-progress
> reload is interruptible. `should_interrupt` awaits a oneshot channel that the
> dispatch task sends on at the very start of `reload()`, reporting whether the
> reload is a `:reload` (interruptible) or a full restart (not interruptible).
>
> ## The bug
>
> ### Step 1: a dispatch gets detached
>
> When `should_interrupt` returns `false` (e.g. for a `Restart`-kind reload),
> the `recv()` arm evaluates to `None` and `handle_event` returns
> `HandleResult::Done`. The dispatch task's `JoinHandle` is dropped without
> calling `abort()` -- but the spawned tokio task keeps running and **continues
> holding the mutex**.
>
> ### Step 2: the next dispatch blocks on the mutex
>
> On the next call to `handle_event`, a new dispatch is spawned. It calls
> `ghci.lock().await`, which blocks because the old (detached) dispatch still
> holds the lock. The new dispatch never reaches `reload()` and therefore never
> sends on its oneshot channel.
>
> ### Step 3: `should_interrupt` blocks forever
>
> If yet another file event arrives, the `recv()` arm wins the `select!` and
> calls `should_interrupt(reload_receiver).await`. This awaits the **new**
> dispatch's oneshot -- but the new dispatch is blocked on the mutex and will
> never send. The main task is now stuck inside `should_interrupt`, which is
> **inside** the `select!` arm, so `exited_receiver`, `on_shutdown_requested`,
> and the task-completion arm are no longer being polled.
>
> ### Result
>
> The main task is permanently stuck. It cannot:
>
> - Process new file events.
> - Detect that ghci crashed (via `exited_receiver`).
> - Respond to shutdown signals.
>
> If the detached dispatch eventually finishes (e.g. a slow restart completes),
> everything drains and recovers -- this manifests as a temporary hang. But if
> ghci crashes during the detached dispatch's `initialize()` call, the
> `IncrementalReader::read_until` loop hits EOF and yields forever, holding the
> mutex permanently. This is the **permanent** deadlock.
>
> ### Concrete scenario
>
> ```
> 1.  .cabal file changes
>       --> handle_event spawns dispatch A
> 2.  Dispatch A acquires lock, sends Restart kind, enters restart_inner()
>       (kills old ghci, starts new one, compiles -- slow)
> 3.  File event B arrives; recv() wins the select
>       --> should_interrupt receives Restart --> returns false
>       --> handle_event returns Done
>       --> dispatch A is now DETACHED, still holding the lock
> 4.  File event C arrives
>       --> handle_event spawns dispatch B
>       --> B calls ghci.lock().await --> BLOCKED (A holds it)
> 5.  File event D arrives; recv() wins the select
>       --> should_interrupt awaits B's oneshot
>       --> B hasn't sent (blocked on mutex)
>       --> MAIN TASK STUCK
> ```
>
> ### Why `--no-interrupt-reloads` avoids the bug
>
> With the flag, the condition `if interrupt_reloads && ...` short-circuits.
> `should_interrupt` is never called. The `recv()` arm returns `None`
> immediately, and the main loop keeps cycling. It can always return to the
> `select!` and poll `exited_receiver`, so it remains responsive even when
> dispatch tasks queue up on the mutex.
>
> ### Secondary bug: event loss
>
> When `should_interrupt` returns `false`, the `new_event` that triggered the
> `recv()` arm is silently dropped. File changes that arrive during a
> non-interruptible reload are lost and never processed.
>
> ## The fix
>
> Wrap the `select!` in a loop. When the `recv()` arm fires and we choose not
> to interrupt, merge the new event into a `pending_event` accumulator and
> `continue` back into the `select!` instead of returning `HandleResult::Done`.
>
> This ensures:
>
> - **No detached dispatches.** `handle_event` stays in the loop until the
>   dispatch task completes (or ghci exits, or shutdown is requested). There is
>   never more than one dispatch task alive, so the mutex is never contended.
>
> - **`should_interrupt` never blocks.** Because there is no prior dispatch
>   holding the lock, the current dispatch acquires it immediately and sends
>   the reload kind before any file event can arrive.
>
> - **No event loss.** Events that arrive during a non-interruptible dispatch
>   are merged into `pending_event` and returned as `HandleResult::Interrupted`
>   for the main loop to retry.
>
> - **Crash/shutdown remain responsive.** The `select!` still polls
>   `exited_receiver` and `on_shutdown_requested` on every iteration of the
>   loop.
