### PR TITLE
DUX-5080 Add `--log-filter-json`

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -368,6 +368,15 @@ Path to write JSON logs to.
 JSON logs are not yet stable and the format may change on any release.
 
 </dd>
+<dt><a id="--log-filter-json" href="#--log-filter-json"><code>--log-filter-json &lt;FILTER&gt;</code></a></dt><dd>
+
+Log message filter for JSON logs.
+
+Defaults to the value of `--log-filter` if not provided. This allows you to log at a more verbose level to the JSON log file without cluttering the terminal output.
+
+See `--log-filter` for the filter syntax.
+
+</dd>
 
 </dl>
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -225,6 +225,15 @@ pub struct LoggingOpts {
     /// JSON logs are not yet stable and the format may change on any release.
     #[arg(long, value_name = "PATH")]
     pub log_json: Option<Utf8PathBuf>,
+
+    /// Log message filter for JSON logs.
+    ///
+    /// Defaults to the value of `--log-filter` if not provided. This allows you to log at a more
+    /// verbose level to the JSON log file without cluttering the terminal output.
+    ///
+    /// See `--log-filter` for the filter syntax.
+    #[arg(long, env = "GHCIWATCH_LOG_JSON", value_name = "FILTER")]
+    pub log_filter_json: Option<String>,
 }
 
 impl Opts {

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -21,12 +21,14 @@ use crate::cli::Opts;
 /// Options for initializing the [`tracing`] logging framework. This is like a lower-effort builder
 /// interface, mostly provided because Rust tragically lacks named arguments.
 pub struct TracingOpts<'opts> {
-    /// Filter directives to control which events are logged.
+    /// Filter directives to control which events are logged to the terminal.
     pub filter_directives: &'opts str,
     /// Control which span events are logged.
     pub trace_spans: &'opts [FmtSpan],
     /// If given, log as JSON to the given path.
     pub json_log_path: Option<&'opts Utf8Path>,
+    /// Filter directives for JSON logs. Falls back to `filter_directives` if `None`.
+    pub json_filter_directives: Option<&'opts str>,
     /// Are we running in TUI mode?
     ///
     /// A `(reader, writer)` pair to write to the TUI.
@@ -41,6 +43,7 @@ impl<'opts> TracingOpts<'opts> {
             filter_directives: &opts.logging.log_filter,
             trace_spans: &opts.logging.trace_spans,
             json_log_path: opts.logging.log_json.as_deref(),
+            json_filter_directives: opts.logging.log_filter_json.as_deref(),
             tui: if opts.has_experimental_feature(ExperimentalFeature::Tui) {
                 Some(tokio::io::duplex(crate::buffers::TRACING_BUFFER_CAPACITY))
             } else {
@@ -84,7 +87,10 @@ impl<'opts> TracingOpts<'opts> {
 
         match &self.json_log_path {
             Some(path) => {
-                let json_layer = tracing_json_layer(self.filter_directives, path, fmt_span)?;
+                let json_filter = self
+                    .json_filter_directives
+                    .unwrap_or(self.filter_directives);
+                let json_layer = tracing_json_layer(json_filter, path, fmt_span)?;
                 registry.with(json_layer).init();
             }
             None => {


### PR DESCRIPTION
This will let us log different messages to the JSON logs and the terminal, reducing verbosity (particularly in tests) significantly.

See:
- https://github.com/MercuryTechnologies/ghciwatch/pull/393#issuecomment-4271429918