### PR TITLE
DUX-5081 Use `--log-filter-json` in tests

### DIFF
--- a/test-harness/src/ghciwatch.rs
+++ b/test-harness/src/ghciwatch.rs
@@ -42,6 +42,7 @@ pub struct GhciWatchBuilder {
     default_timeout: Duration,
     startup_timeout: Duration,
     log_filters: Vec<String>,
+    log_filters_json: Vec<String>,
 }
 
 impl GhciWatchBuilder {
@@ -58,6 +59,7 @@ impl GhciWatchBuilder {
             default_timeout: Duration::from_secs(7),
             startup_timeout: Duration::from_secs(10),
             log_filters: Default::default(),
+            log_filters_json: Default::default(),
         }
     }
 
@@ -153,6 +155,61 @@ impl GhciWatchBuilder {
         self.log_filters
             .extend(log_filters.into_iter().map(|s| s.as_ref().to_owned()));
         self
+    }
+
+    /// Add a `--log-filter-json` clause to the `ghciwatch` invocation.
+    pub fn with_log_filter_json(mut self, log_filter_json: impl AsRef<str>) -> Self {
+        self.log_filters_json
+            .push(log_filter_json.as_ref().to_owned());
+        self
+    }
+
+    /// Add multiple `--log-filter-json` clauses to the `ghciwatch` invocation.
+    pub fn with_log_filters_json(
+        mut self,
+        log_filter_jsons: impl IntoIterator<Item = impl AsRef<str>>,
+    ) -> Self {
+        self.log_filters_json
+            .extend(log_filter_jsons.into_iter().map(|s| s.as_ref().to_owned()));
+        self
+    }
+
+    fn get_log_filters_inner<const N: usize>(
+        env_var: &str,
+        default_filters: [&str; N],
+        builder_filters: &[String],
+    ) -> String {
+        let env_var_filters = match std::env::var(env_var) {
+            Ok(var) => {
+                vec![var]
+            }
+            Err(std::env::VarError::NotPresent) => {
+                vec![]
+            }
+            Err(err @ std::env::VarError::NotUnicode(_)) => {
+                tracing::warn!("${env_var} isn't UTF-8: {err}");
+                vec![]
+            }
+        };
+
+        let mut filters = default_filters
+            .into_iter()
+            .chain(builder_filters.iter().map(|s| s.as_ref()))
+            .chain(env_var_filters.iter().map(|s| s.as_ref()));
+
+        filters.join(",")
+    }
+
+    fn get_log_filters(&self) -> String {
+        Self::get_log_filters_inner("GHCIWATCH_LOG", ["info"], &self.log_filters)
+    }
+
+    fn get_json_log_filters(&self) -> String {
+        Self::get_log_filters_inner(
+            "GHCIWATCH_LOG_JSON",
+            ["ghciwatch=debug"],
+            &self.log_filters_json,
+        )
     }
 }
 
@@ -288,11 +345,6 @@ impl GhciWatch {
 
         let repl_command = shell_words::join(repl_command);
 
-        let log_filters = ["ghciwatch::watcher=trace", "ghciwatch=debug"]
-            .into_iter()
-            .chain(builder.log_filters.iter().map(|s| s.as_ref()))
-            .join(",");
-
         let command = ClonableCommand::new(test_bin::get_test_bin("ghciwatch").get_program())
             .arg("--log-json")
             .arg(&log_path)
@@ -304,7 +356,9 @@ impl GhciWatch {
                 "--watch",
                 "my-simple-package.cabal", // This is going to get me in trouble.
                 "--log-filter",
-                &log_filters,
+                &builder.get_log_filters(),
+                "--log-filter-json",
+                &builder.get_json_log_filters(),
                 "--trace-spans",
                 "new,close",
                 "--poll",

--- a/tests/clear.rs
+++ b/tests/clear.rs
@@ -9,7 +9,7 @@ use test_harness::GhciWatchBuilder;
 async fn clears_on_reload_and_restart() {
     let mut session = GhciWatchBuilder::new("tests/data/simple")
         .with_args(["--clear", "--restart-glob", "**/*.cabal"])
-        .with_log_filter("ghciwatch::ghci[clear]=trace")
+        .with_log_filter_json("ghciwatch::ghci[clear]=trace")
         .start()
         .await
         .expect("ghciwatch starts");

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -186,7 +186,7 @@ async fn hooks_can_observe_error_log() {
             "--after-restart-shell",
             &after_restart,
         ])
-        .with_log_filter("ghciwatch::ghci[run_hooks]=trace")
+        .with_log_filter_json("ghciwatch::ghci[run_hooks]=trace")
         .start()
         .await
         .expect("ghciwatch starts");


### PR DESCRIPTION
This reduces test verbosity significantly, making it much easier to debug failing tests.

See:
- #425

<details><summary>Before (953 lines)</summary>

```
   Compiling ghciwatch v1.3.2 (/Users/wiggles/ghciwatch)
   Compiling test-harness v0.1.0 (/Users/wiggles/ghciwatch/test-harness)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 7.83s
────────────
 Nextest run ID 7ca8a7a5-f62e-48a8-9046-9f8187be4d30 with nextest profile: default
    Starting 1 test across 19 binaries (220 tests skipped)
       START             ghciwatch::all_good can_detect_compilation_failure_9102

running 1 test
2026-04-22T23:20:50.799234Z  INFO can_detect_compilation_failure_9102: test_harness::ghciwatch: Copying project files paths_to_copy=["tests/data/simple"]
2026-04-22T23:20:50.800781Z  INFO can_detect_compilation_failure_9102: test_harness::ghciwatch: Starting ghciwatch
2026-04-22T23:20:50.800848Z  INFO can_detect_compilation_failure_9102: test_harness::ghciwatch: Starting ghciwatch
2026-04-22T23:20:50.801757Z DEBUG can_detect_compilation_failure_9102:wait_for_path{self=Fs { sleep_duration: None } duration=7s path="/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/ghciwatch.json"}: test_harness::fs: Waiting 527.349958ms before retrying
DEBUG new
  in spawn
DEBUG close
  in spawn
DEBUG new
  in spawn
DEBUG close
  in spawn
DEBUG new
  in wait_for_shutdown
DEBUG new
  in run_ghci
DEBUG new
  in run_watcher
DEBUG new
  in ghci
  in run_ghci
DEBUG new
  in before_startup_shell
  in ghci
  in run_ghci
DEBUG close
  in before_startup_shell
  in ghci
  in run_ghci
DEBUG notify watcher started
  in run_watcher
DEBUG Started ghci
  pid=27188
  pgid=27188
  in ghci
  in run_ghci
DEBUG close
  in ghci
  in run_ghci
DEBUG new
  in stderr
DEBUG new
  in initialize
  in run_ghci
DEBUG new
  in ghci_process
DEBUG No error log path, not writing
  in initialize
  in run_ghci
DEBUG new
  in stdout_initialize
  in initialize
  in run_ghci
DEBUG Read stderr line line="Configuration is affected by the following files:"
  in stderr
Configuration is affected by the following files:
DEBUG Read stderr line line="- cabal.project"
  in stderr
- cabal.project
DEBUG Read stderr line
  line="Warning: No remote package servers have been specified. Usually you would have"
  in stderr
Warning: No remote package servers have been specified. Usually you would have
DEBUG Read stderr line line="one specified in the config file."
  in stderr
one specified in the config file.
Resolving dependencies...
DEBUG Read line line="Resolving dependencies..."
  in stdout_initialize
  in initialize
  in run_ghci
Build profile: -w ghc-9.10.2 -O1
DEBUG Read line line="Build profile: -w ghc-9.10.2 -O1"
  in stdout_initialize
  in initialize
  in run_ghci
In order, the following will be built (use -v for more details):
DEBUG Read line
  line="In order, the following will be built (use -v for more details):"
  in stdout_initialize
  in initialize
  in run_ghci
 - my-simple-package-0.1.0.0 (interactive) (lib) (first run)

DEBUG Read line line=" - my-simple-package-0.1.0.0 (interactive) (lib) (first
  run)"
  in stdout_initialize
  in initialize
  in run_ghci

Configuring library for my-simple-package-0.1.0.0...
DEBUG Read line line="Configuring library for my-simple-package-0.1.0.0..."
  in stdout_initialize
  in initialize
  in run_ghci
Preprocessing library for my-simple-package-0.1.0.0...
DEBUG Read line line="Preprocessing library for my-simple-package-0.1.0.0..."
  in stdout_initialize
  in initialize
  in run_ghci
GHCi, version 9.10.2: https://www.haskell.org/ghc/  :? for help
DEBUG ghci started, saw version marker
  data="Resolving dependencies...\nBuild profile: -w ghc-9.10.2 -O1\nIn order, the following will be built (use -v for more details):\n - my-simple-package-0.1.0.0 (interactive) (lib) (first run)\nConfiguring library for my-simple-package-0.1.0.0...\nPreprocessing library for my-simple-package-0.1.0.0...\n"
  in stdout_initialize
  in initialize
  in run_ghci
DEBUG new
  in parse_into_log
  in stdout_initialize
  in initialize
  in run_ghci
DEBUG new
  in get_buffer
  in stderr
DEBUG Drained stderr buffer in 52.50ms
  in get_buffer
  in stderr
DEBUG close
  in get_buffer
  in stderr
DEBUG Ignoring GHC output line line="Resolving dependencies...\n"
  in parse_into_log
  in stdout_initialize
  in initialize
  in run_ghci
DEBUG Ignoring GHC output line line="Build profile: -w ghc-9.10.2 -O1\n"
  in parse_into_log
  in stdout_initialize
  in initialize
  in run_ghci
DEBUG Ignoring GHC output line
  line="In order, the following will be built (use -v for more details):\n"
  in parse_into_log
  in stdout_initialize
  in initialize
  in run_ghci
DEBUG Ignoring GHC output line
  line=" - my-simple-package-0.1.0.0 (interactive) (lib) (first run)\n"
  in parse_into_log
  in stdout_initialize
  in initialize
  in run_ghci
DEBUG Ignoring GHC output line
  line="Configuring library for my-simple-package-0.1.0.0...\n"
  in parse_into_log
  in stdout_initialize
  in initialize
  in run_ghci
DEBUG Ignoring GHC output line
  line="Preprocessing library for my-simple-package-0.1.0.0...\n"
  in parse_into_log
  in stdout_initialize
  in initialize
  in run_ghci
DEBUG Ignoring GHC output line
  line="Configuration is affected by the following files:\n"
  in parse_into_log
  in stdout_initialize
  in initialize
  in run_ghci
DEBUG Ignoring GHC output line line="- cabal.project\n"
  in parse_into_log
  in stdout_initialize
  in initialize
  in run_ghci
DEBUG Ignoring GHC output line
  line="Warning: No remote package servers have been specified. Usually you would have\n"
  in parse_into_log
  in stdout_initialize
  in initialize
  in run_ghci
DEBUG Ignoring GHC output line line="one specified in the config file.\n"
  in parse_into_log
  in stdout_initialize
  in initialize
  in run_ghci
DEBUG close
  in parse_into_log
  in stdout_initialize
  in initialize
  in run_ghci
DEBUG close
  in stdout_initialize
  in initialize
  in run_ghci
DEBUG new
  in stdin_initialize{log=CompilationLog { summary: None, diagnostics: [] }}
  in initialize
  in run_ghci
DEBUG new
  in write_line_with_prompt_at{line=":set prompt ###~GHCIWATCH-PROMPT~###\n" find=Anywhere log=CompilationLog { summary: None, diagnostics: [] }}
  in stdin_initialize{log=CompilationLog { summary: None, diagnostics: [] }}
  in initialize
  in run_ghci
DEBUG new
  in prompt
  in write_line_with_prompt_at{line=":set prompt ###~GHCIWATCH-PROMPT~###\n" find=Anywhere log=CompilationLog { summary: None, diagnostics: [] }}
  in stdin_initialize{log=CompilationLog { summary: None, diagnostics: [] }}
  in initialize
  in run_ghci
[1 of 1] Compiling MyLib            ( src/MyLib.hs, interpreted )
DEBUG Read line
  line="[1 of 1] Compiling MyLib            ( src/MyLib.hs, interpreted )"
  in prompt
  in write_line_with_prompt_at{line=":set prompt ###~GHCIWATCH-PROMPT~###\n" find=Anywhere log=CompilationLog { summary: None, diagnostics: [] }}
  in stdin_initialize{log=CompilationLog { summary: None, diagnostics: [] }}
  in initialize
  in run_ghci
Ok, one module loaded.
DEBUG Read line line="Ok, one module loaded."
  in prompt
  in write_line_with_prompt_at{line=":set prompt ###~GHCIWATCH-PROMPT~###\n" find=Anywhere log=CompilationLog { summary: None, diagnostics: [] }}
  in stdin_initialize{log=CompilationLog { summary: None, diagnostics: [] }}
  in initialize
  in run_ghci
DEBUG Got data from ghci bytes=89
  in prompt
  in write_line_with_prompt_at{line=":set prompt ###~GHCIWATCH-PROMPT~###\n" find=Anywhere log=CompilationLog { summary: None, diagnostics: [] }}
  in stdin_initialize{log=CompilationLog { summary: None, diagnostics: [] }}
  in initialize
  in run_ghci
DEBUG new
  in parse_into_log
  in prompt
  in write_line_with_prompt_at{line=":set prompt ###~GHCIWATCH-PROMPT~###\n" find=Anywhere log=CompilationLog { summary: None, diagnostics: [] }}
  in stdin_initialize{log=CompilationLog { summary: None, diagnostics: [] }}
  in initialize
  in run_ghci
DEBUG new
  in get_buffer
  in stderr
DEBUG Drained stderr buffer in 52.07ms
  in get_buffer
  in stderr
DEBUG close
  in get_buffer
  in stderr
DEBUG Compiling
  module=MyLib
  path=src/MyLib.hs
  current=1
  total=1
  reason=""
  in parse_into_log
  in prompt
  in write_line_with_prompt_at{line=":set prompt ###~GHCIWATCH-PROMPT~###\n" find=Anywhere log=CompilationLog { summary: None, diagnostics: [] }}
  in stdin_initialize{log=CompilationLog { summary: None, diagnostics: [] }}
  in initialize
  in run_ghci
DEBUG Compilation succeeded
  in parse_into_log
  in prompt
  in write_line_with_prompt_at{line=":set prompt ###~GHCIWATCH-PROMPT~###\n" find=Anywhere log=CompilationLog { summary: None, diagnostics: [] }}
  in stdin_initialize{log=CompilationLog { summary: None, diagnostics: [] }}
  in initialize
  in run_ghci
DEBUG close
  in parse_into_log
  in prompt
  in write_line_with_prompt_at{line=":set prompt ###~GHCIWATCH-PROMPT~###\n" find=Anywhere log=CompilationLog { summary: None, diagnostics: [] }}
  in stdin_initialize{log=CompilationLog { summary: None, diagnostics: [] }}
  in initialize
  in run_ghci
DEBUG close
  in prompt
  in write_line_with_prompt_at{line=":set prompt ###~GHCIWATCH-PROMPT~###\n" find=Anywhere log=CompilationLog { summary: None, diagnostics: [] }}
  in stdin_initialize{log=CompilationLog { summary: None, diagnostics: [] }}
  in initialize
  in run_ghci
DEBUG close
  in write_line_with_prompt_at{line=":set prompt ###~GHCIWATCH-PROMPT~###\n" find=Anywhere log=CompilationLog { summary: None, diagnostics: [] }}
  in stdin_initialize{log=CompilationLog { summary: None, diagnostics: [] }}
  in initialize
  in run_ghci
DEBUG new
  in write_line_with_prompt_at{line=":set prompt-cont ###~GHCIWATCH-PROMPT~###\n" find=LineStart log=CompilationLog { summary: Some(CompilationSummary { result: Ok, modules_loaded: Count(1) }), diagnostics: [] }}
  in stdin_initialize{log=CompilationLog { summary: None, diagnostics: [] }}
  in initialize
  in run_ghci
DEBUG new
  in prompt
  in write_line_with_prompt_at{line=":set prompt-cont ###~GHCIWATCH-PROMPT~###\n" find=LineStart log=CompilationLog { summary: Some(CompilationSummary { result: Ok, modules_loaded: Count(1) }), diagnostics: [] }}
  in stdin_initialize{log=CompilationLog { summary: None, diagnostics: [] }}
  in initialize
  in run_ghci
DEBUG Got data from ghci bytes=0
  in prompt
  in write_line_with_prompt_at{line=":set prompt-cont ###~GHCIWATCH-PROMPT~###\n" find=LineStart log=CompilationLog { summary: Some(CompilationSummary { result: Ok, modules_loaded: Count(1) }), diagnostics: [] }}
  in stdin_initialize{log=CompilationLog { summary: None, diagnostics: [] }}
  in initialize
  in run_ghci
DEBUG new
  in parse_into_log
  in prompt
  in write_line_with_prompt_at{line=":set prompt-cont ###~GHCIWATCH-PROMPT~###\n" find=LineStart log=CompilationLog { summary: Some(CompilationSummary { result: Ok, modules_loaded: Count(1) }), diagnostics: [] }}
  in stdin_initialize{log=CompilationLog { summary: None, diagnostics: [] }}
  in initialize
  in run_ghci
DEBUG new
  in get_buffer
  in stderr
DEBUG Drained stderr buffer in 52.07ms
  in get_buffer
  in stderr
DEBUG close
  in get_buffer
  in stderr
DEBUG close
  in parse_into_log
  in prompt
  in write_line_with_prompt_at{line=":set prompt-cont ###~GHCIWATCH-PROMPT~###\n" find=LineStart log=CompilationLog { summary: Some(CompilationSummary { result: Ok, modules_loaded: Count(1) }), diagnostics: [] }}
  in stdin_initialize{log=CompilationLog { summary: None, diagnostics: [] }}
  in initialize
  in run_ghci
DEBUG close
  in prompt
  in write_line_with_prompt_at{line=":set prompt-cont ###~GHCIWATCH-PROMPT~###\n" find=LineStart log=CompilationLog { summary: Some(CompilationSummary { result: Ok, modules_loaded: Count(1) }), diagnostics: [] }}
  in stdin_initialize{log=CompilationLog { summary: None, diagnostics: [] }}
  in initialize
  in run_ghci
DEBUG close
  in write_line_with_prompt_at{line=":set prompt-cont ###~GHCIWATCH-PROMPT~###\n" find=LineStart log=CompilationLog { summary: Some(CompilationSummary { result: Ok, modules_loaded: Count(1) }), diagnostics: [] }}
  in stdin_initialize{log=CompilationLog { summary: None, diagnostics: [] }}
  in initialize
  in run_ghci
DEBUG close
  in stdin_initialize{log=CompilationLog { summary: None, diagnostics: [] }}
  in initialize
  in run_ghci
DEBUG new
  in refresh_targets
  in initialize
  in run_ghci
DEBUG new
  in refresh_paths
  in refresh_targets
  in initialize
  in run_ghci
DEBUG new
  in show_paths
  in refresh_paths
  in refresh_targets
  in initialize
  in run_ghci
DEBUG new
  in show_paths
  in show_paths
  in refresh_paths
  in refresh_targets
  in initialize
  in run_ghci
DEBUG Read line line="current working directory: "
  in show_paths
  in show_paths
  in refresh_paths
  in refresh_targets
  in initialize
  in run_ghci
DEBUG Read line
  line="  /private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple"
  in show_paths
  in show_paths
  in refresh_paths
  in refresh_targets
  in initialize
  in run_ghci
DEBUG Read line line="module import search paths:"
  in show_paths
  in show_paths
  in refresh_paths
  in refresh_targets
  in initialize
  in run_ghci
DEBUG Read line line="  src"
  in show_paths
  in show_paths
  in refresh_paths
  in refresh_targets
  in initialize
  in run_ghci
DEBUG Read line
  line="  dist-newstyle/build/aarch64-osx/ghc-9.10.2/my-simple-package-0.1.0.0/build"
  in show_paths
  in show_paths
  in refresh_paths
  in refresh_targets
  in initialize
  in run_ghci
DEBUG Read line
  line="  dist-newstyle/build/aarch64-osx/ghc-9.10.2/my-simple-package-0.1.0.0/build/autogen"
  in show_paths
  in show_paths
  in refresh_paths
  in refresh_targets
  in initialize
  in run_ghci
DEBUG Read line
  line="  dist-newstyle/build/aarch64-osx/ghc-9.10.2/my-simple-package-0.1.0.0/build/global-autogen"
  in show_paths
  in show_paths
  in refresh_paths
  in refresh_targets
  in initialize
  in run_ghci
DEBUG close
  in show_paths
  in show_paths
  in refresh_paths
  in refresh_targets
  in initialize
  in run_ghci
DEBUG close
  in show_paths
  in refresh_paths
  in refresh_targets
  in initialize
  in run_ghci
DEBUG Parsed paths
  cwd=/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple
  search_paths=["/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/dist-newstyle/build/aarch64-osx/ghc-9.10.2/my-simple-package-0.1.0.0/build/global-autogen", "/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/dist-newstyle/build/aarch64-osx/ghc-9.10.2/my-simple-package-0.1.0.0/build/autogen", "/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src", "/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/dist-newstyle/build/aarch64-osx/ghc-9.10.2/my-simple-package-0.1.0.0/build"]
  in refresh_paths
  in refresh_targets
  in initialize
  in run_ghci
DEBUG close
  in refresh_paths
  in refresh_targets
  in initialize
  in run_ghci
DEBUG new
  in show_targets
  in refresh_targets
  in initialize
  in run_ghci
DEBUG new
  in show_targets
  in show_targets
  in refresh_targets
  in initialize
  in run_ghci
DEBUG Read line line="MyLib"
  in show_targets
  in show_targets
  in refresh_targets
  in initialize
  in run_ghci
DEBUG close
  in show_targets
  in show_targets
  in refresh_targets
  in initialize
  in run_ghci
DEBUG close
  in show_targets
  in refresh_targets
  in initialize
  in run_ghci
DEBUG Parsed targets targets=1
  in refresh_targets
  in initialize
  in run_ghci
DEBUG close
  in refresh_targets
  in initialize
  in run_ghci
DEBUG new
  in refresh_eval_commands
  in initialize
  in run_ghci
DEBUG close
  in refresh_eval_commands
  in initialize
  in run_ghci
DEBUG new
  in error_log_write
  in initialize
  in run_ghci
DEBUG No error log path, not writing
  in error_log_write
  in initialize
  in run_ghci
DEBUG close
  in error_log_write
  in initialize
  in run_ghci
• All good! Finished starting up in 4.22s
  in initialize
  in run_ghci
DEBUG new
  in eval
  in initialize
  in run_ghci
DEBUG close
  in eval
  in initialize
  in run_ghci
DEBUG new
  in test
  in initialize
  in run_ghci
DEBUG close
  in test
  in initialize
  in run_ghci
DEBUG close
  in initialize
  in run_ghci
DEBUG new
  in handle_event_inner
TRACE Got events
  events=[DebouncedEvent { event: Event { kind: Modify(Metadata(WriteTime)), paths: ["/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs"], attr:tracker: None, attr:flag: None, attr:info: None, attr:source: None }, time: Instant { tv_sec: 199505, tv_nsec: 239173416 } }]
  in handle_event_inner
TRACE Processed events
  events={Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")}
  in handle_event_inner
DEBUG close
  in handle_event_inner
DEBUG Received ghci event from watcher
  event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }
  in run_ghci
DEBUG new
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG new
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG Needs reload path=src/MyLib.hs
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG No error log path, not writing
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}

• Reloading ghci:
  • src/MyLib.hs
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}

DEBUG new
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG new
  in write_line_with_prompt_at{line=":reload\n" find=LineStart log=CompilationLog { summary: None, diagnostics: [] }}
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG new
  in prompt
  in write_line_with_prompt_at{line=":reload\n" find=LineStart log=CompilationLog { summary: None, diagnostics: [] }}
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
[1 of 1] Compiling MyLib            ( src/MyLib.hs, interpreted ) [Source file changed]
DEBUG Read line
  line="[1 of 1] Compiling MyLib            ( src/MyLib.hs, interpreted ) [Source file changed]"
  in prompt
  in write_line_with_prompt_at{line=":reload\n" find=LineStart log=CompilationLog { summary: None, diagnostics: [] }}
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG Read stderr line
  line="\u{1b}[;1msrc/MyLib.hs:4:11: \u{1b}[;1m\u{1b}[31merror\u{1b}[0m\u{1b}[0m\u{1b}[;1m: [GHC-83865]\u{1b}[0m\u{1b}[0m\u{1b}[;1m"
  in stderr
[;1msrc/MyLib.hs:4:11: [;1m[31merror[0m[0m[;1m: [GHC-83865][0m[0m[;1m
DEBUG Read stderr line line="    * Couldn't match type `[Char]' with `()'"
  in stderr
    * Couldn't match type `[Char]' with `()'
Failed, no modules to be reloaded.
DEBUG Read stderr line line="      Expected: ()"
  in stderr
DEBUG Read line line="Failed, no modules to be reloaded."
  in prompt
  in write_line_with_prompt_at{line=":reload\n" find=LineStart log=CompilationLog { summary: None, diagnostics: [] }}
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
      Expected: ()
DEBUG Read stderr line line="        Actual: String"
  in stderr
        Actual: String
DEBUG Read stderr line line="    * In the expression: \"example\""
  in stderr
    * In the expression: "example"
DEBUG Got data from ghci bytes=123
  in prompt
  in write_line_with_prompt_at{line=":reload\n" find=LineStart log=CompilationLog { summary: None, diagnostics: [] }}
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG Read stderr line
  line="      In an equation for `example': example = \"example\"\u{1b}[0m\u{1b}[0m"
  in stderr
      In an equation for `example': example = "example"[0m[0m
DEBUG Read stderr line line="\u{1b}[;1m\u{1b}[34m  |\u{1b}[0m\u{1b}[0m"
  in stderr
DEBUG new
  in parse_into_log
  in prompt
  in write_line_with_prompt_at{line=":reload\n" find=LineStart log=CompilationLog { summary: None, diagnostics: [] }}
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
[;1m[34m  |[0m[0m
DEBUG Read stderr line
  line="\u{1b}[;1m\u{1b}[34m4 |\u{1b}[0m\u{1b}[0m example = \u{1b}[;1m\u{1b}[31m\"example\"\u{1b}[0m\u{1b}[0m"
  in stderr
[;1m[34m4 |[0m[0m example = [;1m[31m"example"[0m[0m
DEBUG Read stderr line
  line="\u{1b}[;1m\u{1b}[34m  |\u{1b}[0m\u{1b}[0m\u{1b}[;1m\u{1b}[31m           ^^^^^^^^^\u{1b}[0m\u{1b}[0m"
  in stderr
[;1m[34m  |[0m[0m[;1m[31m           ^^^^^^^^^[0m[0m
DEBUG new
  in get_buffer
  in stderr
DEBUG Read stderr line line=""
  in get_buffer
  in stderr

DEBUG Drained stderr buffer in 51.62ms
  in get_buffer
  in stderr
DEBUG close
  in get_buffer
  in stderr
DEBUG Compiling
  module=MyLib
  path=src/MyLib.hs
  current=1
  total=1
  reason="[Source file changed]"
  in parse_into_log
  in prompt
  in write_line_with_prompt_at{line=":reload\n" find=LineStart log=CompilationLog { summary: None, diagnostics: [] }}
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG Compilation failed
  in parse_into_log
  in prompt
  in write_line_with_prompt_at{line=":reload\n" find=LineStart log=CompilationLog { summary: None, diagnostics: [] }}
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG Ignoring GHC output line line="\n"
  in parse_into_log
  in prompt
  in write_line_with_prompt_at{line=":reload\n" find=LineStart log=CompilationLog { summary: None, diagnostics: [] }}
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG Module failed to compile
  path=src/MyLib.hs
  error="[GHC-83865]\n    * Couldn't match type `[Char]' with `()'\n      Expected: ()\n        Actual: String\n    * In the expression: \"example\"\n      In an equation for `example': example = \"example\"\n  |\n4 | example = \"example\"\n  |           ^^^^^^^^^\n"
  in parse_into_log
  in prompt
  in write_line_with_prompt_at{line=":reload\n" find=LineStart log=CompilationLog { summary: None, diagnostics: [] }}
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG close
  in parse_into_log
  in prompt
  in write_line_with_prompt_at{line=":reload\n" find=LineStart log=CompilationLog { summary: None, diagnostics: [] }}
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG close
  in prompt
  in write_line_with_prompt_at{line=":reload\n" find=LineStart log=CompilationLog { summary: None, diagnostics: [] }}
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG close
  in write_line_with_prompt_at{line=":reload\n" find=LineStart log=CompilationLog { summary: None, diagnostics: [] }}
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG close
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG new
  in refresh_eval_commands_for_paths
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG close
  in refresh_eval_commands_for_paths
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG new
  in error_log_write
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG No error log path, not writing
  in error_log_write
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG close
  in error_log_write
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
⚠ Reloading failed in 62.27ms
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG close
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG close
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG Finished dispatching ghci event
  in run_ghci
DEBUG new
  in handle_event_inner
TRACE Got events
  events=[DebouncedEvent { event: Event { kind: Modify(Metadata(WriteTime)), paths: ["/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs"], attr:tracker: None, attr:flag: None, attr:info: None, attr:source: None }, time: Instant { tv_sec: 199507, tv_nsec: 246711791 } }]
  in handle_event_inner
TRACE Processed events
  events={Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")}
  in handle_event_inner
DEBUG close
  in handle_event_inner
DEBUG Received ghci event from watcher
  event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }
  in run_ghci
DEBUG new
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG new
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG Needs reload path=src/MyLib.hs
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG No error log path, not writing
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}

• Reloading ghci:
  • src/MyLib.hs
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}

DEBUG new
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG new
  in write_line_with_prompt_at{line=":reload\n" find=LineStart log=CompilationLog { summary: None, diagnostics: [] }}
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG new
  in prompt
  in write_line_with_prompt_at{line=":reload\n" find=LineStart log=CompilationLog { summary: None, diagnostics: [] }}
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
[1 of 1] Compiling MyLib            ( src/MyLib.hs, interpreted )
DEBUG Read line
  line="[1 of 1] Compiling MyLib            ( src/MyLib.hs, interpreted )"
  in prompt
  in write_line_with_prompt_at{line=":reload\n" find=LineStart log=CompilationLog { summary: None, diagnostics: [] }}
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
Ok, one module reloaded.
DEBUG Read line line="Ok, one module reloaded."
  in prompt
  in write_line_with_prompt_at{line=":reload\n" find=LineStart log=CompilationLog { summary: None, diagnostics: [] }}
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG Got data from ghci bytes=91
  in prompt
  in write_line_with_prompt_at{line=":reload\n" find=LineStart log=CompilationLog { summary: None, diagnostics: [] }}
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG new
  in parse_into_log
  in prompt
  in write_line_with_prompt_at{line=":reload\n" find=LineStart log=CompilationLog { summary: None, diagnostics: [] }}
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG new
  in get_buffer
  in stderr
DEBUG Drained stderr buffer in 51.47ms
  in get_buffer
  in stderr
DEBUG close
  in get_buffer
  in stderr
DEBUG Compiling
  module=MyLib
  path=src/MyLib.hs
  current=1
  total=1
  reason=""
  in parse_into_log
  in prompt
  in write_line_with_prompt_at{line=":reload\n" find=LineStart log=CompilationLog { summary: None, diagnostics: [] }}
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG Compilation succeeded
  in parse_into_log
  in prompt
  in write_line_with_prompt_at{line=":reload\n" find=LineStart log=CompilationLog { summary: None, diagnostics: [] }}
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG close
  in parse_into_log
  in prompt
  in write_line_with_prompt_at{line=":reload\n" find=LineStart log=CompilationLog { summary: None, diagnostics: [] }}
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG close
  in prompt
  in write_line_with_prompt_at{line=":reload\n" find=LineStart log=CompilationLog { summary: None, diagnostics: [] }}
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG close
  in write_line_with_prompt_at{line=":reload\n" find=LineStart log=CompilationLog { summary: None, diagnostics: [] }}
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG close
  in reload
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG new
  in refresh_eval_commands_for_paths
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG close
  in refresh_eval_commands_for_paths
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG new
  in error_log_write
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG No error log path, not writing
  in error_log_write
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG close
  in error_log_write
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
• All good! Finished reloading in 62.53ms
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG new
  in eval
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG close
  in eval
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG new
  in test
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG close
  in test
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG close
  in reload
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG close
  in dispatch{event=Reload { events: {Modify("/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpOCM85t/simple/src/MyLib.hs")} }}
DEBUG Finished dispatching ghci event
  in run_ghci

thread 'can_detect_compilation_failure_9102' panicked at tests/all_good.rs:44:10:
called `Result::unwrap()` on an `Err` value:   × Waiting for a log message matching "All goop!" timed out after 7.00s

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Wrote logs to /Users/wiggles/ghciwatch/target/tmp/test_harness-internal-can_detect_compilation_failure_9102.json
DEBUG Ctrl-C pressed, shutting down gracefully
  in wait_for_shutdown
DEBUG new
  in stop
  in ghci_process
DEBUG new
  in stop
  in run_ghci
DEBUG close
  in stderr
DEBUG Killing ghci process tree with SIGKILL
  in stop
  in ghci_process
DEBUG close
  in stop
  in run_ghci
DEBUG Task completed successfully task="stderr"
DEBUG close
  in run_ghci
DEBUG Task completed successfully task="run_ghci"
DEBUG ghci exited: signal: 9 (SIGKILL)
  in stop
  in ghci_process
DEBUG close
  in stop
  in ghci_process
DEBUG close
  in ghci_process
DEBUG Task completed successfully task="ghci_process"
DEBUG close
  in run_watcher
DEBUG All tasks finished
  in wait_for_shutdown
DEBUG Task completed successfully task="run_watcher"
DEBUG new
  in cancel_tasks
  in wait_for_shutdown
DEBUG Task is finished task="run_ghci"
  in cancel_tasks
  in wait_for_shutdown
DEBUG Task is finished task="run_watcher"
  in cancel_tasks
  in wait_for_shutdown
DEBUG Task is finished task="stderr"
  in cancel_tasks
  in wait_for_shutdown
DEBUG Task is finished task="ghci_process"
  in cancel_tasks
  in wait_for_shutdown
DEBUG close
  in cancel_tasks
  in wait_for_shutdown
DEBUG new
  in check_task_failures
  in wait_for_shutdown
DEBUG All tasks completed successfully
  in check_task_failures
  in wait_for_shutdown
DEBUG close
  in check_task_failures
  in wait_for_shutdown
DEBUG Finished shutdown in 10.97ms
  in wait_for_shutdown
DEBUG close
  in wait_for_shutdown
DEBUG main() finished
2026-04-22T23:21:06.011498Z  INFO can_detect_compilation_failure_9102: test_harness::internal: ghciwatch exited status=exit status: 0
test can_detect_compilation_failure_9102 ... FAILED

failures:

failures:
    can_detect_compilation_failure_9102

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 3 filtered out; finished in 15.37s

        FAIL [  15.974s] ghciwatch::all_good can_detect_compilation_failure_9102
  Cancelling due to test failure
────────────
     Summary [  15.974s] 1 test run: 0 passed, 1 failed, 220 skipped
        FAIL [  15.974s] ghciwatch::all_good can_detect_compilation_failure_9102
error: test run failed
```

</details>


<details><summary>After (49 lines)</summary>

```
$ cargo nextest run --no-capture can_detect_compilation_failure_9102
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.09s
────────────
 Nextest run ID 3b3612ae-4fe4-4ff4-a7e3-9447005f4e3b with nextest profile: default
    Starting 1 test across 19 binaries (220 tests skipped)
       START             ghciwatch::all_good can_detect_compilation_failure_9102

running 1 test
2026-04-22T23:19:22.938753Z  INFO can_detect_compilation_failure_9102: test_harness::ghciwatch: Copying project files paths_to_copy=["tests/data/simple"]
2026-04-22T23:19:22.940689Z  INFO can_detect_compilation_failure_9102: test_harness::ghciwatch: Starting ghciwatch
2026-04-22T23:19:22.940751Z  INFO can_detect_compilation_failure_9102: test_harness::ghciwatch: Starting ghciwatch
2026-04-22T23:19:22.941487Z DEBUG can_detect_compilation_failure_9102:wait_for_path{self=Fs { sleep_duration: None } duration=7s path="/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/.tmpM5XNsc/ghciwatch.json"}: test_harness::fs: Waiting 612.775732ms before retrying
Configuration is affected by the following files:
- cabal.project
Warning: No remote package servers have been specified. Usually you would have
one specified in the config file.
Resolving dependencies...
Build profile: -w ghc-9.10.2 -O1
In order, the following will be built (use -v for more details):
 - my-simple-package-0.1.0.0 (interactive) (lib) (first run)
Configuring library for my-simple-package-0.1.0.0...
Preprocessing library for my-simple-package-0.1.0.0...
GHCi, version 9.10.2: https://www.haskell.org/ghc/  :? for help
[1 of 1] Compiling MyLib            ( src/MyLib.hs, interpreted )
Ok, one module loaded.
• All good! Finished starting up in 4.06s

• Reloading ghci:
  • src/MyLib.hs

[1 of 1] Compiling MyLib            ( src/MyLib.hs, interpreted ) [Source file changed]
src/MyLib.hs:4:11: error: [GHC-83865]
    * Couldn't match type `[Char]' with `()'
Failed, no modules to be reloaded.
      Expected: ()
        Actual: String
    * In the expression: "example"
      In an equation for `example': example = "example"
  |
4 | example = "example"
  |           ^^^^^^^^^

⚠ Reloading failed in 63.11ms

• Reloading ghci:
  • src/MyLib.hs

[1 of 1] Compiling MyLib            ( src/MyLib.hs, interpreted )
Ok, one module reloaded.
• All good! Finished reloading in 61.72ms

thread 'can_detect_compilation_failure_9102' panicked at tests/all_good.rs:44:10:
called `Result::unwrap()` on an `Err` value:   × Waiting for a log message matching "All goop!" timed out after 7.00s

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Wrote logs to /Users/wiggles/ghciwatch/target/tmp/test_harness-internal-can_detect_compilation_failure_9102.json
2026-04-22T23:19:37.568992Z  INFO can_detect_compilation_failure_9102: test_harness::internal: ghciwatch exited status=exit status: 0
test can_detect_compilation_failure_9102 ... FAILED

failures:

failures:
    can_detect_compilation_failure_9102

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 3 filtered out; finished in 14.74s

        FAIL [  15.320s] ghciwatch::all_good can_detect_compilation_failure_9102
  Cancelling due to test failure
────────────
     Summary [  15.321s] 1 test run: 0 passed, 1 failed, 220 skipped
        FAIL [  15.320s] ghciwatch::all_good can_detect_compilation_failure_9102
error: test run failed
```

</details>