### PR TITLE
DUX-5095 stdout: add `buffer_and_drain_prompts` and `read_until_marker`

### DIFF
--- a/src/ghci/stdout.rs
+++ b/src/ghci/stdout.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use aho_corasick::AhoCorasick;
 use miette::Context;
 use miette::IntoDiagnostic;
@@ -96,6 +98,42 @@ impl GhciStdout {
 
         self.parse_into_log(&data, log).await?;
         Ok(())
+    }
+
+    /// Read any immediately-available output from the pipe, then drain stale prompts from
+    /// the internal buffer. Returns the number of prompts found and discarded.
+    #[expect(unused)]
+    pub async fn buffer_and_drain_prompts(&mut self, timeout: Duration) -> miette::Result<usize> {
+        self.reader
+            .buffer_available(&mut self.buffer, timeout, WriteBehavior::NoFinalLine)
+            .await?;
+
+        self.reader
+            .drain_buffered_chunks(&ReadOpts {
+                end_marker: &self.prompt_patterns,
+                find: FindAt::Anywhere,
+                writing: WriteBehavior::NoFinalLine,
+                buffer: &mut self.buffer,
+            })
+            .await
+    }
+
+    /// Read stdout until the given marker string is found, discarding everything before it.
+    ///
+    /// Used by `send_sigint` to synchronize with GHCi after an interrupt: a sync expression
+    /// is sent on stdin and this method reads until its output appears, guaranteeing that all
+    /// prior output has been consumed.
+    #[expect(unused)]
+    pub async fn read_until_marker(&mut self, marker: &str) -> miette::Result<String> {
+        let pattern = AhoCorasick::from_anchored_patterns([marker]);
+        self.reader
+            .read_until(&mut ReadOpts {
+                end_marker: &pattern,
+                find: FindAt::Anywhere,
+                writing: WriteBehavior::NoFinalLine,
+                buffer: &mut self.buffer,
+            })
+            .await
     }
 
     #[instrument(skip_all, level = "debug")]

--- a/src/incremental_reader.rs
+++ b/src/incremental_reader.rs
@@ -177,7 +177,6 @@ where
     /// This method is cancel-safe: decoded data is stored in `self.pending` (synchronously,
     /// before any `.await`) so it survives if the future is dropped. Any un-forwarded data in
     /// `pending` is drained on the next operation via [`Self::drain_pending`].
-    #[expect(unused)]
     pub async fn buffer_available(
         &mut self,
         buffer: &mut [u8],
@@ -419,7 +418,6 @@ where
     ///
     /// This is used after `send_sigint` to discard stale prompts left behind by an aborted
     /// `prompt()` call. Returns the number of chunks drained.
-    #[cfg_attr(not(test), expect(unused))]
     pub async fn drain_buffered_chunks(&mut self, opts: &ReadOpts<'_>) -> miette::Result<usize> {
         self.drain_pending(opts.writing).await?;
         let mut count = 0;


### PR DESCRIPTION
Thin wrappers over `IncrementalReader`'s new buffering methods, used by the upcoming `send_sigint` rewrite:

- `buffer_and_drain_prompts`: polls for available output then discards any prompt matches already in the buffer
- `read_until_marker`: reads until an arbitrary marker string appears, used for the sync barrier protocol