### PR TITLE
DUX-5102 Local package error paths are incorrect

### DIFF
--- a/src/ghci/compilation_log.rs
+++ b/src/ghci/compilation_log.rs
@@ -1,3 +1,5 @@
+use camino::Utf8Path;
+
 use crate::ghci::parse::CompilationResult;
 use crate::ghci::parse::CompilationSummary;
 use crate::ghci::parse::GhcDiagnostic;
@@ -12,6 +14,14 @@ pub struct CompilationLog {
 }
 
 impl CompilationLog {
+    /// Make the diagnostic paths for this log relative to a different directory.
+    pub fn relocate(&mut self, old_base: &Utf8Path, new_base: &Utf8Path) -> miette::Result<()> {
+        for diagnostic in self.diagnostics.iter_mut() {
+            diagnostic.make_relative_to(old_base, new_base)?;
+        }
+        Ok(())
+    }
+
     /// Get the result of compilation.
     pub fn result(&self) -> Option<CompilationResult> {
         self.summary.map(|summary| summary.result)

--- a/src/ghci/error_log.rs
+++ b/src/ghci/error_log.rs
@@ -1,10 +1,11 @@
-use camino::Utf8PathBuf;
 use miette::Context;
 use miette::IntoDiagnostic;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 use tokio::io::BufWriter;
 use tracing::instrument;
+
+use crate::normal_path::NormalPath;
 
 use super::parse::CompilationResult;
 use super::parse::ModulesLoaded;
@@ -22,13 +23,20 @@ const STILL_COMPILING: &str = "[ghciwatch is still compiling]";
 /// This produces `ghcid`-compatible output, which can be consumed by `ghcid` plugins in your
 /// editor of choice.
 pub struct ErrorLog {
-    path: Option<Utf8PathBuf>,
+    path: Option<NormalPath>,
 }
 
 impl ErrorLog {
     /// Construct a new error log writer for the given path.
-    pub fn new(path: Option<Utf8PathBuf>) -> Self {
+    pub fn new(path: Option<NormalPath>) -> Self {
         Self { path }
+    }
+
+    /// Get the path this error log is written to.
+    ///
+    /// Paths in GHC error messages are written to this path.
+    pub fn path(&self) -> Option<&NormalPath> {
+        self.path.as_ref()
     }
 
     /// Write the "still compiling" message to the error log before a reload or restart.

--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -382,7 +382,10 @@ impl Ghci {
             })
             .await;
 
-        let error_log = ErrorLog::new(opts.error_path.clone());
+        let error_log = ErrorLog::new(match &opts.error_path {
+            Some(error_path) => Some(NormalPath::from_cwd(error_path)?),
+            None => None,
+        });
         let classifier =
             FileClassifier::new(opts.restart_globs.clone(), opts.reload_globs.clone())?;
 
@@ -1019,6 +1022,10 @@ impl Ghci {
         log: &mut CompilationLog,
         events: [LifecycleEvent; N],
     ) -> miette::Result<()> {
+        if let Some(error_log_dir) = self.error_log.path().and_then(|path| path.parent()) {
+            log.relocate(&self.search_paths.cwd, error_log_dir)?;
+        }
+
         // Allow hooks to consume the error log by updating it before running the hooks.
         self.write_error_log(log).await?;
 

--- a/src/ghci/parse/ghc_message/mod.rs
+++ b/src/ghci/parse/ghc_message/mod.rs
@@ -2,6 +2,7 @@
 
 use std::fmt::Display;
 
+use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use miette::miette;
 use winnow::combinator::alt;
@@ -44,6 +45,8 @@ use module_import_cycle_diagnostic::module_import_cycle_diagnostic;
 
 mod no_location_info_diagnostic;
 use no_location_info_diagnostic::no_location_info_diagnostic;
+
+use crate::normal_path::NormalPath;
 
 use super::rest_of_line;
 
@@ -122,6 +125,41 @@ pub struct GhcDiagnostic {
     pub span: PositionRange,
     /// The associated message.
     pub message: String,
+}
+
+impl GhcDiagnostic {
+    /// Make this diagnostic's path (if it exists) relative to a different directory.
+    ///
+    /// If you run `cabal repl my-package`, where `my-package` is a package listed in the
+    /// `cabal.project` in a different directory than the one where you run `cabal repl` from, then
+    /// `:show paths` will say the working directory is (e.g.) `my-package`, and paths in error
+    /// messages will be written relative to the _working directory_ and _not_ the directory you
+    /// launch `cabal repl` from (or the directory you write your error log to).
+    ///
+    /// Therefore, this method lets us rewrite the paths in diagnostics to be relative to a
+    /// different directory, e.g. for usage with [`static-ls`][static-ls] or the ghcid VS Code
+    /// plugin.
+    ///
+    /// [static-ls]: https://github.com/josephsumabat/static-ls
+    pub fn make_relative_to(
+        &mut self,
+        old_base: &Utf8Path,
+        new_base: &Utf8Path,
+    ) -> miette::Result<()> {
+        if let Some(path) = self.path.take() {
+            tracing::trace!(
+                %path, %old_base, %new_base,
+                "Relocating GHC diagnostic"
+            );
+            self.path = Some(
+                NormalPath::new(path, old_base)?
+                    .relocate(new_base)?
+                    .into_relative(),
+            );
+        }
+
+        Ok(())
+    }
 }
 
 impl Display for GhcDiagnostic {

--- a/src/normal_path.rs
+++ b/src/normal_path.rs
@@ -50,6 +50,11 @@ impl NormalPath {
         Self::new(original, crate::current_dir()?)
     }
 
+    /// Relocate this path to be relative to a different base directory.
+    pub fn relocate(&self, new_base: impl AsRef<Path>) -> miette::Result<Self> {
+        Self::new(self.absolute(), new_base)
+    }
+
     /// Get a reference to the absolute (normalized) path, borrowed as a [`Utf8Path`].
     pub fn absolute(&self) -> &Utf8Path {
         self.normal.as_path()
@@ -245,5 +250,22 @@ mod tests {
 
         assert_eq!(path.absolute(), Utf8Path::new("a/b/c/d/e/f"));
         assert_eq!(path.relative(), Utf8Path::new("d/e/f"));
+    }
+
+    #[test]
+    fn test_normalpath_relocate() {
+        let relative = Utf8Path::new("src/Lib.hs");
+        let base = Utf8Path::new("/var/my-project/my-package");
+        let new_base = Utf8Path::new("/var/my-project");
+        let path = NormalPath::new(relative, base)
+            .unwrap()
+            .relocate(new_base)
+            .unwrap();
+
+        assert_eq!(
+            path.absolute(),
+            Utf8Path::new("/var/my-project/my-package/src/Lib.hs")
+        );
+        assert_eq!(path.relative(), Utf8Path::new("my-package/src/Lib.hs"));
     }
 }


### PR DESCRIPTION
If you run `cabal repl my-package`, where `my-package` is a package listed in the `cabal.project` in a different directory than the one where you run `cabal repl` from, then `:show paths` will say the working directory is (e.g.) `my-package`, and paths in error messages will be written relative to the *working directory* and *not* the directory you launch `cabal repl` from (or the directory you write your error log to).

This causes problems with `static-ls` with the `--error-log` argument.

Therefore, we'll "relocate" the error paths to be relative to the error log's directory instead.
