### PR TITLE
DUX-5101 No "All good" after startup

### DIFF
--- a/src/ghci/compilation_log.rs
+++ b/src/ghci/compilation_log.rs
@@ -6,6 +6,8 @@ use crate::ghci::parse::GhcDiagnostic;
 use crate::ghci::parse::GhcMessage;
 use crate::ghci::parse::Severity;
 
+use super::parse::ModulesLoaded;
+
 /// A log of messages from compilation, used to write the error log.
 #[derive(Debug, Clone, Default)]
 pub struct CompilationLog {
@@ -20,6 +22,15 @@ impl CompilationLog {
             diagnostic.make_relative_to(old_base, new_base)?;
         }
         Ok(())
+    }
+
+    /// If we start up in `--repl-no-load`, we don't get a compilation summary, but we don't want to
+    /// leave the error log empty, so we synthesize an "All good (0 modules)" message.
+    pub fn fill_empty_summary(&mut self) {
+        self.summary.get_or_insert(CompilationSummary {
+            result: CompilationResult::Ok,
+            modules_loaded: ModulesLoaded::Count(0),
+        });
     }
 
     /// Get the result of compilation.

--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -434,6 +434,11 @@ impl Ghci {
         // Get the initial list of eval commands.
         self.refresh_eval_commands().await?;
 
+        // If we're in `--repl-no-load`, we may not have gotten a summary message. In that case,
+        // fill in an empty "All good (0 modules)" message.
+        //
+        // Note: We ONLY want to do this on startup.
+        log.fill_empty_summary();
         self.finish_compilation(start_instant, log, events).await?;
 
         Ok(())


### PR DESCRIPTION
With `--repl-no-load`, we don't get a compilation summary message ("Ok, 123 modules loaded."), so if everything went well we write... an _empty_ error log, which is not helpful.

Let's synthesize a message in this case: "All good (0 modules)".

NB: If compilation for a _dependency_ fails during startup, we don't yet handle that.