### PR TITLE
DUX-5106 miette -> eyre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -92,7 +92,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -162,15 +162,6 @@ dependencies = [
  "object",
  "rustc-demangle",
  "windows-link",
-]
-
-[[package]]
-name = "backtrace-ext"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
-dependencies = [
- "backtrace",
 ]
 
 [[package]]
@@ -306,6 +297,33 @@ name = "clonable-command"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4140de6168fe09fe790bf37d6dfdd269f313d23ff9e99cc4e3a8aec6a65f619b"
+
+[[package]]
+name = "color-eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors 4.3.0",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
+dependencies = [
+ "once_cell",
+ "owo-colors 4.3.0",
+ "tracing-core",
+ "tracing-error",
+]
 
 [[package]]
 name = "colorchoice"
@@ -487,7 +505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -518,6 +536,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63af43ff4431e848fb47472a920f14fa71c24de13255a5692e93d4e90302acb0"
 dependencies = [
  "dissimilar",
+ "once_cell",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
  "once_cell",
 ]
 
@@ -660,19 +688,20 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "clearscreen",
+ "color-eyre",
  "command-group",
  "crossterm",
  "enum-iterator",
  "expect-test",
+ "eyre",
  "humantime",
  "ignore",
  "indoc 1.0.9",
  "itertools 0.11.0",
  "line-span",
- "miette",
  "nix",
  "notify-debouncer-full",
- "owo-colors",
+ "owo-colors 3.5.0",
  "path-absolutize",
  "pathdiff",
  "pretty_assertions",
@@ -783,6 +812,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
 name = "indoc"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,7 +869,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -974,38 +1009,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
-name = "miette"
-version = "5.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
-dependencies = [
- "backtrace",
- "backtrace-ext",
- "is-terminal",
- "miette-derive",
- "once_cell",
- "owo-colors",
- "supports-color 2.1.0",
- "supports-hyperlinks",
- "supports-unicode",
- "terminal_size 0.1.17",
- "textwrap 0.15.2",
- "thiserror 1.0.69",
- "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "miette-derive"
-version = "5.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,7 +1106,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1141,6 +1144,12 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 dependencies = [
  "supports-color 1.3.1",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking"
@@ -1437,7 +1446,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1675,24 +1684,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "supports-hyperlinks"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84231692eb0d4d41e4cdd0cabfdd2e6cd9e255e65f80c9aa7c98dd502b4233d"
-dependencies = [
- "is-terminal",
-]
-
-[[package]]
-name = "supports-unicode"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f850c19edd184a205e883199a261ed44471c81e39bd95b1357f5febbef00e77a"
-dependencies = [
- "is-terminal",
-]
-
-[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,17 +1721,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1782,10 +1763,10 @@ version = "0.1.0"
 dependencies = [
  "backoff",
  "clonable-command",
+ "eyre",
  "fs_extra",
  "futures-util",
  "itertools 0.11.0",
- "miette",
  "nix",
  "regex",
  "serde",
@@ -1812,17 +1793,6 @@ name = "test_bin"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e7a7de15468c6e65dd7db81cf3822c1ec94c71b2a3c1a976ea8e4696c91115c"
-
-[[package]]
-name = "textwrap"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
-dependencies = [
- "smawk",
- "unicode-linebreak",
- "unicode-width 0.1.14",
-]
 
 [[package]]
 name = "textwrap"
@@ -2015,15 +1985,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-human-layer"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8f92b4e494498c79204e07cbdea4ad7a39a806198fa95a3e578223963ba59ab"
 dependencies = [
  "itertools 0.11.0",
- "owo-colors",
+ "owo-colors 3.5.0",
  "parking_lot",
- "textwrap 0.16.2",
+ "textwrap",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2202,7 +2182,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,27 +1,22 @@
 [workspace]
-members = [
-    "test-harness",
-    "test-harness-macro",
-]
+members = ["test-harness", "test-harness-macro"]
 resolver = "2"
 
 # See: https://github.com/crate-ci/cargo-release/blob/master/docs/reference.md
 [workspace.metadata.release]
 # Set the commit message.
 pre-release-commit-message = "Release {{crate_name}} version {{version}}"
-consolidate-commits = false # One commit per crate.
-tag = false # Don't tag commits.
-push = false # Don't do `git push`.
-publish = false # Don't do `cargo publish`.
+consolidate-commits = false                                               # One commit per crate.
+tag = false                                                               # Don't tag commits.
+push = false                                                              # Don't do `git push`.
+publish = false                                                           # Don't do `cargo publish`.
 
 # Define the root package: https://doc.rust-lang.org/cargo/reference/workspaces.html#root-package
 [package]
 name = "ghciwatch"
 version = "1.3.3"
 edition = "2021"
-authors = [
-    "Rebecca Turner <rebeccat@mercury.com>"
-]
+authors = ["Rebecca Turner <rebeccat@mercury.com>"]
 description = "Ghciwatch loads a GHCi session for a Haskell project and reloads it when source files change."
 readme = "README.md"
 homepage = "https://github.com/MercuryTechnologies/ghciwatch"
@@ -46,22 +41,28 @@ clap = { version = "~4.4", features = ["derive", "wrap_help", "env", "string"] }
 clap_complete = "~4.4"
 clap_mangen = { version = "=0.2.19", optional = true }
 clearscreen = "2.0.1"
+color-eyre = "0.6.5"
 command-group = { version = "2.1.0", features = ["tokio", "with-tokio"] }
 crossterm = { version = "0.27.0", features = ["event-stream"] }
 enum-iterator = "1.4.1"
+eyre = { version = "0.6.12", default-features = false, features = [
+  "track-caller",
+] }
 humantime = "2.3.0"
 ignore = "0.4.20"
 indoc = "1.0.6"
 itertools = "0.11.0"
 line-span = "0.1.5"
-miette = { version = "5.9.0", features = ["fancy"] }
-nix = { version = "0.26.2", default-features = false, features = ["process", "signal"] }
+nix = { version = "0.26.2", default-features = false, features = [
+  "process",
+  "signal",
+] }
 notify-debouncer-full = "0.3.1"
 owo-colors = { version = "3.5.0", features = ["supports-colors"] }
 path-absolutize = "3.1.1"
 pathdiff = { version = "0.2.1", features = ["camino"] }
 ratatui = "=0.26.1" # 0.26.2 needs Rust 1.72.
-saturating = "0.1.0"  # Needed until we have Rust 1.74.
+saturating = "0.1.0" # Needed until we have Rust 1.74.
 shell-words = "1.1.0"
 strip-ansi-escapes = "0.2.0"
 supports-color = "2.1.0"
@@ -71,7 +72,12 @@ tokio-util = { version = "0.7.10", features = ["compat", "io-util"] }
 tracing = "0.1.37"
 tracing-appender = "0.2.3"
 tracing-human-layer = "0.1.3"
-tracing-subscriber = { version = "0.3.17", features = ["env-filter", "time", "json", "registry"] }
+tracing-subscriber = { version = "0.3.17", features = [
+  "env-filter",
+  "time",
+  "json",
+  "registry",
+] }
 winnow = "0.5.15"
 
 [dev-dependencies]

--- a/src/clap/humantime.rs
+++ b/src/clap/humantime.rs
@@ -6,9 +6,6 @@ use clap::builder::StringValueParser;
 use clap::builder::TypedValueParser;
 use clap::builder::ValueParserFactory;
 use humantime::DurationError;
-use miette::LabeledSpan;
-use miette::MietteDiagnostic;
-use miette::Report;
 
 use super::value_validation_error;
 
@@ -29,50 +26,23 @@ impl TypedValueParser for DurationValueParser {
     ) -> Result<Self::Value, clap::Error> {
         self.inner.parse_ref(cmd, arg, value).and_then(|str_value| {
             humantime::parse_duration(&str_value).map_err(|err| {
-                let diagnostic = Report::new(MietteDiagnostic {
-                    message: match &err {
-                        DurationError::InvalidCharacter(_) => "Invalid character".to_owned(),
-                        DurationError::NumberExpected(_) => "Expected number".to_owned(),
-                        DurationError::UnknownUnit { unit, .. } => format!("Unknown unit `{unit}`"),
-                        DurationError::NumberOverflow => "Duration is too long".to_owned(),
-                        DurationError::Empty => "No duration given".to_owned(),
-                    },
-                    code: None,
-                    severity: None,
-                    help: match &err {
-                        DurationError::InvalidCharacter(_) => {
-                            Some("Non-alphanumeric characters are prohibited".to_owned())
-                        }
-                        DurationError::NumberExpected(_) => {
-                            Some("Did you split a unit into multiple words?".to_owned())
-                        }
-                        DurationError::UnknownUnit { .. } => Some(
-                            "Valid units include `ms` (milliseconds) and `s` (seconds)".to_owned(),
-                        ),
-                        DurationError::NumberOverflow => None,
-                        DurationError::Empty => None,
-                    },
-                    url: None,
-                    labels: match err {
-                        DurationError::InvalidCharacter(offset) => Some(vec![LabeledSpan::at(
-                            offset..offset + 1,
-                            "Invalid character",
-                        )]),
-                        DurationError::NumberExpected(offset) => {
-                            Some(vec![LabeledSpan::at(offset..offset + 1, "Expected number")])
-                        }
-                        DurationError::UnknownUnit {
-                            start,
-                            end,
-                            unit: _,
-                            value: _,
-                        } => Some(vec![LabeledSpan::at(start..end, "Unknown unit")]),
-                        DurationError::NumberOverflow => None,
-                        DurationError::Empty => None,
-                    },
-                })
-                .with_source_code(str_value.clone());
-                value_validation_error(arg, &str_value, format!("{diagnostic:?}"))
+                // NB: These error messages are not as good as they were with `miette`, but
+                // they're not exactly common so I don't really want to add the `miette` dependency
+                // back just for this.
+                let message = match &err {
+                    DurationError::InvalidCharacter(offset) => format!(
+                        "Invalid character at offset {offset}; non-alphanumeric characters are prohibited"
+                    ),
+                    DurationError::NumberExpected(offset) => format!(
+                        "Expected number at offset {offset}; did you split a unit into multiple words?"
+                    ),
+                    DurationError::UnknownUnit { unit, .. } => format!(
+                        "Unknown unit `{unit}`; valid units include `ms` (milliseconds) and `s` (seconds)"
+                    ),
+                    DurationError::NumberOverflow => "Duration is too long".to_owned(),
+                    DurationError::Empty => "No duration given".to_owned(),
+                };
+                value_validation_error(arg, &str_value, message)
             })
         })
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -171,12 +171,12 @@ pub struct WatchOpts {
 
 impl WatchOpts {
     /// Build the specified globs into a matcher.
-    pub fn reload_globs(&self) -> miette::Result<GlobMatcher> {
+    pub fn reload_globs(&self) -> eyre::Result<GlobMatcher> {
         GlobMatcher::from_globs(self.reload_globs.iter())
     }
 
     /// Build the specified globs into a matcher.
-    pub fn restart_globs(&self) -> miette::Result<GlobMatcher> {
+    pub fn restart_globs(&self) -> eyre::Result<GlobMatcher> {
         GlobMatcher::from_globs(self.restart_globs.iter())
     }
 }
@@ -249,7 +249,7 @@ impl Opts {
 
     /// Perform late initialization of the command-line arguments. If `init` isn't called before
     /// the arguments are used, the behavior is undefined.
-    pub fn init(&mut self) -> miette::Result<()> {
+    pub fn init(&mut self) -> eyre::Result<()> {
         if let Some(file) = &self.file {
             self.watch.paths.push(file.clone());
         } else if self.watch.paths.is_empty() {

--- a/src/clonable_command.rs
+++ b/src/clonable_command.rs
@@ -9,9 +9,8 @@ use std::str::FromStr;
 use clap::builder::StringValueParser;
 use clap::builder::TypedValueParser;
 use clap::builder::ValueParserFactory;
-use miette::miette;
-use miette::Context;
-use miette::IntoDiagnostic;
+use eyre::eyre;
+use eyre::Context;
 use tokio::process::Command;
 
 use crate::command_ext::CommandExt;
@@ -150,15 +149,14 @@ impl ClonableCommand {
 }
 
 impl FromStr for ClonableCommand {
-    type Err = miette::Report;
+    type Err = eyre::Report;
 
     fn from_str(shell_command: &str) -> Result<Self, Self::Err> {
         let tokens = shell_words::split(shell_command.trim())
-            .into_diagnostic()
             .wrap_err_with(|| format!("Failed to split shell command: {shell_command:?}"))?;
 
         match &*tokens {
-            [] => Err(miette!("Command has no program: {shell_command:?}")),
+            [] => Err(eyre!("Command has no program: {shell_command:?}")),
             [program] => Ok(ClonableCommand {
                 program: program.into(),
                 ..Default::default()

--- a/src/cwd.rs
+++ b/src/cwd.rs
@@ -1,20 +1,17 @@
 use std::path::PathBuf;
 
 use camino::Utf8PathBuf;
-use miette::miette;
-use miette::Context;
-use miette::IntoDiagnostic;
+use eyre::eyre;
+use eyre::Context;
 
 /// Get the current working directory of the process with [`std::env::current_dir`].
-pub fn current_dir() -> miette::Result<PathBuf> {
-    std::env::current_dir()
-        .into_diagnostic()
-        .wrap_err("Failed to get current directory")
+pub fn current_dir() -> eyre::Result<PathBuf> {
+    std::env::current_dir().wrap_err("Failed to get current directory")
 }
 
 /// Get the current working directory of the process as a [`Utf8PathBuf`].
-pub fn current_dir_utf8() -> miette::Result<Utf8PathBuf> {
+pub fn current_dir_utf8() -> eyre::Result<Utf8PathBuf> {
     current_dir()?
         .try_into()
-        .map_err(|path| miette!("Current directory isn't valid UTF-8: {path:?}"))
+        .map_err(|path| eyre!("Current directory isn't valid UTF-8: {path:?}"))
 }

--- a/src/event_filter.rs
+++ b/src/event_filter.rs
@@ -4,7 +4,6 @@ use std::collections::BTreeSet;
 
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
-use miette::IntoDiagnostic;
 use notify_debouncer_full::notify::EventKind;
 use notify_debouncer_full::DebouncedEvent;
 
@@ -34,7 +33,7 @@ impl FileEvent {
 }
 
 /// Process a set of events into a set of [`FileEvent`]s.
-pub fn file_events_from_action(events: Vec<DebouncedEvent>) -> miette::Result<BTreeSet<FileEvent>> {
+pub fn file_events_from_action(events: Vec<DebouncedEvent>) -> eyre::Result<BTreeSet<FileEvent>> {
     let mut ret = BTreeSet::new();
 
     for event in events {
@@ -56,7 +55,7 @@ pub fn file_events_from_action(events: Vec<DebouncedEvent>) -> miette::Result<BT
         }
 
         for path in event.paths {
-            let path: Utf8PathBuf = path.try_into().into_diagnostic()?;
+            let path: Utf8PathBuf = path.try_into()?;
 
             if !path.exists() || removed {
                 ret.insert(FileEvent::Remove(path));

--- a/src/ghci/compilation_log.rs
+++ b/src/ghci/compilation_log.rs
@@ -17,7 +17,7 @@ pub struct CompilationLog {
 
 impl CompilationLog {
     /// Make the diagnostic paths for this log relative to a different directory.
-    pub fn relocate(&mut self, old_base: &Utf8Path, new_base: &Utf8Path) -> miette::Result<()> {
+    pub fn relocate(&mut self, old_base: &Utf8Path, new_base: &Utf8Path) -> eyre::Result<()> {
         for diagnostic in self.diagnostics.iter_mut() {
             diagnostic.make_relative_to(old_base, new_base)?;
         }

--- a/src/ghci/error_log.rs
+++ b/src/ghci/error_log.rs
@@ -1,5 +1,4 @@
-use miette::Context;
-use miette::IntoDiagnostic;
+use eyre::Context;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 use tokio::io::BufWriter;
@@ -40,7 +39,7 @@ impl ErrorLog {
     }
 
     /// Write the "still compiling" message to the error log before a reload or restart.
-    pub async fn write_still_compiling(&self) -> miette::Result<()> {
+    pub async fn write_still_compiling(&self) -> eyre::Result<()> {
         let path = match &self.path {
             Some(path) => path,
             None => {
@@ -51,7 +50,6 @@ impl ErrorLog {
 
         tokio::fs::write(path, STILL_COMPILING)
             .await
-            .into_diagnostic()
             .wrap_err_with(|| "Failed to write error log: {path}")?;
 
         Ok(())
@@ -59,7 +57,7 @@ impl ErrorLog {
 
     /// Write the error log, if any, with the given compilation summary and diagnostic messages.
     #[instrument(skip(self, log), name = "error_log_write", level = "debug")]
-    pub async fn write(&mut self, log: &CompilationLog) -> miette::Result<()> {
+    pub async fn write(&mut self, log: &CompilationLog) -> eyre::Result<()> {
         let path = match &self.path {
             Some(path) => path,
             None => {
@@ -68,7 +66,7 @@ impl ErrorLog {
             }
         };
 
-        let file = File::create(path).await.into_diagnostic()?;
+        let file = File::create(path).await?;
         let mut writer = BufWriter::new(file);
 
         if let Some(summary) = log.summary {
@@ -82,22 +80,18 @@ impl ErrorLog {
                 };
                 writer
                     .write_all(format!("All good ({modules_loaded})\n").as_bytes())
-                    .await
-                    .into_diagnostic()?;
+                    .await?;
             }
         }
 
         for diagnostic in &log.diagnostics {
             tracing::debug!(%diagnostic, "Writing diagnostic");
-            writer
-                .write_all(diagnostic.to_string().as_bytes())
-                .await
-                .into_diagnostic()?;
+            writer.write_all(diagnostic.to_string().as_bytes()).await?;
         }
 
         // This is load-bearing! If we don't properly flush/shutdown the handle, nothing gets
         // written!
-        writer.shutdown().await.into_diagnostic()?;
+        writer.shutdown().await?;
 
         Ok(())
     }

--- a/src/ghci/file_classifier.rs
+++ b/src/ghci/file_classifier.rs
@@ -33,7 +33,7 @@ impl FileClassifier {
     /// current working directory.
     ///
     /// This is suitable for use before GHCi has initialized.
-    pub fn new(restart_globs: GlobMatcher, reload_globs: GlobMatcher) -> miette::Result<Self> {
+    pub fn new(restart_globs: GlobMatcher, reload_globs: GlobMatcher) -> eyre::Result<Self> {
         Ok(Self {
             restart_globs,
             reload_globs,
@@ -47,7 +47,7 @@ impl FileClassifier {
     }
 
     /// Make a path relative to the working directory.
-    pub fn relative_path(&self, path: impl AsRef<Path>) -> miette::Result<NormalPath> {
+    pub fn relative_path(&self, path: impl AsRef<Path>) -> eyre::Result<NormalPath> {
         NormalPath::new(path, &self.cwd)
     }
 
@@ -59,7 +59,7 @@ impl FileClassifier {
         &self,
         events: BTreeSet<FileEvent>,
         targets: &ModuleSet,
-    ) -> miette::Result<ReloadActions> {
+    ) -> eyre::Result<ReloadActions> {
         // Once we know which paths were modified and which paths were removed, we can combine
         // that with information about this `ghci` session to determine which modules need to be
         // reloaded, which modules need to be added, and which modules were removed. In the case

--- a/src/ghci/manager.rs
+++ b/src/ghci/manager.rs
@@ -4,8 +4,7 @@ use std::collections::BTreeSet;
 use std::process::ExitStatus;
 use std::sync::Arc;
 
-use miette::Context;
-use miette::IntoDiagnostic;
+use eyre::Context;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::sync::Mutex;
@@ -57,7 +56,7 @@ pub async fn run_ghci(
     mut handle: ShutdownHandle,
     opts: GhciOpts,
     mut watcher_receiver: mpsc::Receiver<WatcherEvent>,
-) -> miette::Result<()> {
+) -> eyre::Result<()> {
     // This function is pretty tricky! We need to handle shutdowns at each stage, and the process
     // is a little different each time, so the `select!`s can't be consolidated.
 
@@ -120,7 +119,7 @@ async fn dispatch(
     ghci: Arc<Mutex<Ghci>>,
     event: WatcherEvent,
     reload_sender: oneshot::Sender<GhciReloadKind>,
-) -> miette::Result<()> {
+) -> eyre::Result<()> {
     match event {
         WatcherEvent::Reload { events } => {
             ghci.lock().await.reload(events, reload_sender).await?;
@@ -184,7 +183,7 @@ enum HandleResult {
 }
 
 impl GhciManager {
-    async fn run(mut self) -> miette::Result<()> {
+    async fn run(mut self) -> eyre::Result<()> {
         let mut maybe_event: Option<WatcherEvent> = None;
         loop {
             let event = match maybe_event.take() {
@@ -206,7 +205,7 @@ impl GhciManager {
     }
 
     /// Wait for the next watcher event, handling shutdown and ghci death along the way.
-    async fn wait_for_event(&mut self) -> miette::Result<WaitResult> {
+    async fn wait_for_event(&mut self) -> eyre::Result<WaitResult> {
         let ghci_exited = {
             let GhciManager {
                 ref ghci,
@@ -255,7 +254,7 @@ impl GhciManager {
     /// the ghci `Mutex` and deadlock the next iteration. Events that arrive during a
     /// non-interruptible dispatch are accumulated into `pending_event` and returned as
     /// `Interrupted` for retry.
-    async fn handle_event(&mut self, mut event: WatcherEvent) -> miette::Result<HandleResult> {
+    async fn handle_event(&mut self, mut event: WatcherEvent) -> eyre::Result<HandleResult> {
         let (reload_sender, reload_receiver) = oneshot::channel();
         let mut task = Box::pin(tokio::task::spawn(dispatch(
             self.ghci.clone(),
@@ -350,7 +349,7 @@ impl GhciManager {
                                             .recv()
                                             .await
                                             .ok_or_else(|| {
-                                                miette::miette!(
+                                                eyre::eyre!(
                                                     "ghci exit channel closed after kill"
                                                 )
                                             })?;
@@ -373,7 +372,7 @@ impl GhciManager {
                     continue;
                 }
                 ret = &mut task => {
-                    ret.into_diagnostic()??;
+                    ret??;
                     tracing::debug!("Finished dispatching ghci event");
                     None
                 }
@@ -403,10 +402,7 @@ impl GhciManager {
 
     /// Wait for a relevant file change, then attempt to restart ghci.
     #[instrument(level = "debug", skip_all)]
-    async fn wait_and_restart_runtime(
-        &mut self,
-        status: ExitStatus,
-    ) -> miette::Result<RetryResult> {
+    async fn wait_and_restart_runtime(&mut self, status: ExitStatus) -> eyre::Result<RetryResult> {
         wait_and_restart(
             &mut self.handle,
             &mut self.watcher_receiver,
@@ -434,7 +430,7 @@ fn drain_pending(event: &mut WatcherEvent, watcher_receiver: &mut mpsc::Receiver
 /// `Remove` of a Haskell source file as relevant. This may produce a false
 /// positive (e.g. for files in the reload-ignore list), but a needless dispatch
 /// is harmless — the real classify inside `reload()` will filter it out.
-fn is_relevant(event: &WatcherEvent, classifier: &FileClassifier) -> miette::Result<bool> {
+fn is_relevant(event: &WatcherEvent, classifier: &FileClassifier) -> eyre::Result<bool> {
     let WatcherEvent::Reload { ref events } = *event;
     let kind = classifier
         .classify(events.clone(), &ModuleSet::default())?
@@ -456,7 +452,7 @@ fn drain_and_classify(
     initial: WatcherEvent,
     watcher_receiver: &mut mpsc::Receiver<WatcherEvent>,
     classifier: &FileClassifier,
-) -> miette::Result<Option<GhciReloadKind>> {
+) -> eyre::Result<Option<GhciReloadKind>> {
     let mut event = initial;
     drain_pending(&mut event, watcher_receiver);
     let WatcherEvent::Reload { events } = event;
@@ -492,7 +488,7 @@ impl RestartStrategy<'_> {
         }
     }
 
-    async fn restart(&mut self) -> miette::Result<()> {
+    async fn restart(&mut self) -> eyre::Result<()> {
         match self {
             Self::Startup(ghci) => ghci
                 .startup_restart()
@@ -520,7 +516,7 @@ async fn wait_and_restart(
     classifier: &FileClassifier,
     mut status: ExitStatus,
     strategy: &mut RestartStrategy<'_>,
-) -> miette::Result<RetryResult> {
+) -> eyre::Result<RetryResult> {
     let context = strategy.context();
     tracing::warn!(
         %status,

--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -24,9 +24,8 @@ use backoff::backoff::Backoff;
 use backoff::ExponentialBackoff;
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
-use miette::miette;
-use miette::IntoDiagnostic;
-use miette::WrapErr;
+use eyre::eyre;
+use eyre::WrapErr;
 use nix::unistd::Pid;
 use tokio::io::AsyncBufReadExt;
 use tokio::io::BufReader;
@@ -137,7 +136,7 @@ impl GhciOpts {
     ///
     /// If running in TUI mode, `ghci` output (from `stdout_writer` and `stderr_writer`) is sent to
     /// the stream given by the second return value.
-    pub fn from_cli(opts: &Opts) -> miette::Result<(Self, Option<DuplexStream>)> {
+    pub fn from_cli(opts: &Opts) -> eyre::Result<(Self, Option<DuplexStream>)> {
         // TODO: implement fancier default command
         // See: https://github.com/ndmitchell/ghcid/blob/e2852979aa644c8fed92d46ab529d2c6c1c62b59/src/Ghcid.hs#L142-L171
         let command = match (&opts.file, &opts.command) {
@@ -214,7 +213,7 @@ impl GhciOpts {
     ///
     /// The classifier uses the process's current working directory. Call
     /// [`FileClassifier::set_cwd`] after GHCi initialization to update it.
-    pub fn file_classifier(&self) -> miette::Result<FileClassifier> {
+    pub fn file_classifier(&self) -> eyre::Result<FileClassifier> {
         FileClassifier::new(self.restart_globs.clone(), self.reload_globs.clone())
     }
 
@@ -270,7 +269,7 @@ pub struct Ghci {
     /// Search paths / current working directory for this `ghci` session.
     search_paths: ShowPaths,
     /// Tasks running `async:` shell commands in the background.
-    command_handles: Vec<JoinHandle<miette::Result<ExitStatus>>>,
+    command_handles: Vec<JoinHandle<eyre::Result<ExitStatus>>>,
     /// Monotonic counter for generating unique sync barrier nonces.
     sync_nonce: u64,
 }
@@ -293,7 +292,7 @@ impl Ghci {
         mut shutdown: ShutdownHandle,
         opts: GhciOpts,
         exited_sender: mpsc::Sender<ExitStatus>,
-    ) -> miette::Result<Self> {
+    ) -> eyre::Result<Self> {
         let mut command_handles = Vec::new();
         {
             let span = tracing::debug_span!("before_startup_shell");
@@ -317,21 +316,20 @@ impl Ghci {
 
             command
                 .group_spawn()
-                .into_diagnostic()
                 .wrap_err_with(|| format!("Failed to start {}", command.display()))?
         };
 
         let process_group_id = Pid::from_raw(
             group
                 .id()
-                .ok_or_else(|| miette!("ghci process has no process group ID"))? as i32,
+                .ok_or_else(|| eyre!("ghci process has no process group ID"))? as i32,
         );
 
         let child = group.inner();
         let process_id = Pid::from_raw(
             child
                 .id()
-                .ok_or_else(|| miette!("ghci process has no process ID"))? as i32,
+                .ok_or_else(|| eyre!("ghci process has no process ID"))? as i32,
         );
         tracing::debug!(
             pid = process_id.as_raw(),
@@ -418,7 +416,7 @@ impl Ghci {
         &mut self,
         log: &mut CompilationLog,
         events: [LifecycleEvent; N],
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         let start_instant = Instant::now();
 
         self.error_log.write_still_compiling().await?;
@@ -444,7 +442,7 @@ impl Ghci {
         Ok(())
     }
 
-    fn get_reload_actions(&self, events: BTreeSet<FileEvent>) -> miette::Result<ReloadActions> {
+    fn get_reload_actions(&self, events: BTreeSet<FileEvent>) -> eyre::Result<ReloadActions> {
         self.classifier.classify(events, &self.targets)
     }
 
@@ -459,7 +457,7 @@ impl Ghci {
         &mut self,
         events: BTreeSet<FileEvent>,
         kind_sender: oneshot::Sender<GhciReloadKind>,
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         let start_instant = Instant::now();
         let actions = self.get_reload_actions(events)?;
         let _ = kind_sender.send(actions.kind());
@@ -533,7 +531,7 @@ impl Ghci {
     /// really "restarting" a session so much as starting it again. That is, this method avoids
     /// "broken pipe" errors with `--before-restart-ghci` hooks.
     #[instrument(skip_all, level = "debug")]
-    async fn startup_restart(&mut self) -> miette::Result<()> {
+    async fn startup_restart(&mut self) -> eyre::Result<()> {
         let mut log = CompilationLog::default();
 
         self.restart_inner(&mut log, [LifecycleEvent::Startup(hooks::When::After)])
@@ -544,7 +542,7 @@ impl Ghci {
 
     /// Restart the `ghci` session.
     #[instrument(skip_all, level = "debug")]
-    async fn restart(&mut self) -> miette::Result<()> {
+    async fn restart(&mut self) -> eyre::Result<()> {
         let mut log = CompilationLog::default();
 
         self.run_hooks(LifecycleEvent::Restart(hooks::When::Before), &mut log)
@@ -566,7 +564,7 @@ impl Ghci {
         &mut self,
         log: &mut CompilationLog,
         events: [LifecycleEvent; N],
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         self.stop().await?;
         let new = Self::new(
             self.shutdown.clone(),
@@ -582,14 +580,14 @@ impl Ghci {
 
     /// Run the user provided test command.
     #[instrument(skip_all, level = "debug")]
-    async fn test(&mut self, log: &mut CompilationLog) -> miette::Result<()> {
+    async fn test(&mut self, log: &mut CompilationLog) -> eyre::Result<()> {
         self.run_hooks(LifecycleEvent::Test, log).await?;
         Ok(())
     }
 
     /// Run the eval commands, if enabled.
     #[instrument(skip_all, level = "debug")]
-    async fn eval(&mut self, log: &mut CompilationLog) -> miette::Result<()> {
+    async fn eval(&mut self, log: &mut CompilationLog) -> eyre::Result<()> {
         if !self.opts.enable_eval {
             return Ok(());
         }
@@ -623,7 +621,7 @@ impl Ghci {
 
     /// Refresh the listing of targets by parsing the `:show paths` and `:show targets` output.
     #[instrument(skip_all, level = "debug")]
-    async fn refresh_targets(&mut self) -> miette::Result<()> {
+    async fn refresh_targets(&mut self) -> eyre::Result<()> {
         self.refresh_paths().await?;
         self.targets = self
             .stdin
@@ -635,7 +633,7 @@ impl Ghci {
 
     /// Refresh the listing of search paths by parsing the `:show paths` output.
     #[instrument(skip_all, level = "debug")]
-    async fn refresh_paths(&mut self) -> miette::Result<()> {
+    async fn refresh_paths(&mut self) -> eyre::Result<()> {
         self.search_paths = self.stdin.show_paths(&mut self.stdout).await?;
         self.classifier.set_cwd(self.search_paths.cwd.clone());
         tracing::debug!(cwd = %self.search_paths.cwd, search_paths = ?self.search_paths.search_paths, "Parsed paths");
@@ -644,7 +642,7 @@ impl Ghci {
 
     /// Refresh `eval_commands` by reading and parsing the files in `targets`.
     #[instrument(skip_all, level = "debug")]
-    async fn refresh_eval_commands(&mut self) -> miette::Result<()> {
+    async fn refresh_eval_commands(&mut self) -> eyre::Result<()> {
         if !self.opts.enable_eval {
             return Ok(());
         }
@@ -667,7 +665,7 @@ impl Ghci {
     async fn refresh_eval_commands_for_paths(
         &mut self,
         paths: impl IntoIterator<Item = impl Borrow<NormalPath>>,
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         if !self.opts.enable_eval {
             return Ok(());
         }
@@ -698,10 +696,9 @@ impl Ghci {
 
     /// Read and parse eval commands from the given `path`.
     #[instrument(level = "trace")]
-    async fn parse_eval_commands(path: &Utf8Path) -> miette::Result<Vec<EvalCommand>> {
+    async fn parse_eval_commands(path: &Utf8Path) -> eyre::Result<Vec<EvalCommand>> {
         let contents = tokio::fs::read_to_string(path)
             .await
-            .into_diagnostic()
             .wrap_err_with(|| format!("Failed to read {path}"))?;
         let commands = parse_eval_commands(&contents)
             .wrap_err_with(|| format!("Failed to parse eval commands from file {path}"))?;
@@ -714,11 +711,11 @@ impl Ghci {
         &mut self,
         paths: &[NormalPath],
         log: &mut CompilationLog,
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         let mut modules = Vec::with_capacity(paths.len());
         for path in paths {
             if self.targets.contains_source_path(path) {
-                return Err(miette!(
+                return Err(eyre!(
                     "Attempting to add already-loaded module: {path}\n\
                     This is a ghciwatch bug; please report it upstream"
                 ));
@@ -795,7 +792,7 @@ impl Ghci {
         &mut self,
         path: &NormalPath,
         log: &mut CompilationLog,
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         let module = self.targets.get_import_name(path);
 
         self.stdin
@@ -819,7 +816,7 @@ impl Ghci {
         &mut self,
         paths: &[NormalPath],
         log: &mut CompilationLog,
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         let modules = paths
             .iter()
             .map(|path| self.targets.get_import_name(path).into_owned())
@@ -843,7 +840,7 @@ impl Ghci {
 
     /// Stop this `ghci` session and cancel the async tasks associated with it.
     #[instrument(skip_all, level = "debug")]
-    async fn stop(&mut self) -> miette::Result<()> {
+    async fn stop(&mut self) -> eyre::Result<()> {
         // Tell the `GhciProcess` to shut down `ghci` without requesting a shutdown for
         // `ghciwatch`.
         let _ = self.restart_sender.try_send(());
@@ -858,7 +855,7 @@ impl Ghci {
     /// as a session-died event and route through the normal restart path
     /// rather than propagating it as fatal. See [`Ghci::sync_barrier`] for details.
     #[instrument(skip_all, level = "debug")]
-    async fn send_sigint(&mut self) -> miette::Result<()> {
+    async fn send_sigint(&mut self) -> eyre::Result<()> {
         let start_instant = Instant::now();
 
         // Phase 1: Send SIGINT repeatedly until we find a clean, uninterrupted prompt.
@@ -878,7 +875,7 @@ impl Ghci {
         let mut sigint_count: usize = 0;
         loop {
             let Some(delay) = backoff.next_backoff() else {
-                return Err(miette!(
+                return Err(eyre!(
                     "Timed out waiting for GHCi to respond to SIGINT after {:.2?}",
                     start_instant.elapsed()
                 ));
@@ -886,7 +883,6 @@ impl Ghci {
 
             sigint_count += 1;
             signal::killpg(self.process_group_id, Signal::SIGINT)
-                .into_diagnostic()
                 .wrap_err("Failed to send `Ctrl-C` (`SIGINT`) to ghci session")?;
             tracing::debug!(count = sigint_count, "Sent SIGINT");
 
@@ -929,7 +925,7 @@ impl Ghci {
     /// method. This ensures we consume all remaining stale output, without having to wait until we
     /// "think it's safe" and wasting the user's time after GHCi is done writing.
     #[instrument(skip_all, level = "debug")]
-    async fn sync_barrier(&mut self) -> miette::Result<()> {
+    async fn sync_barrier(&mut self) -> eyre::Result<()> {
         self.sync_nonce += 1;
         let nonce = self.sync_nonce;
         let sync_marker = format!("~~~GHCIWATCH-SYNC-{nonce}~~~");
@@ -962,7 +958,7 @@ impl Ghci {
                 .await
                 .wrap_err("Failed to restore prompt after sync barrier"),
             Ok(Err(e)) => Err(e).wrap_err("Failed to read until sync marker"),
-            Err(_elapsed) => Err(miette!(
+            Err(_elapsed) => Err(eyre!(
                 "Timed out waiting for GHCi sync marker after {sync_timeout:?}"
             )),
         };
@@ -974,7 +970,6 @@ impl Ghci {
             // learn ghci died. We need the wait future in `GhciProcess::run` to win the
             // select so `exited_sender` fires and `wait_and_restart_runtime` takes over.
             if let Err(kill_err) = signal::killpg(self.process_group_id, Signal::SIGKILL)
-                .into_diagnostic()
                 .wrap_err("Failed to send `SIGKILL` to ghci session")
             {
                 tracing::error!(
@@ -991,7 +986,7 @@ impl Ghci {
 
     #[allow(dead_code)] // TODO: No it should not be!
     #[instrument(skip_all, level = "trace")]
-    async fn before_startup_shell(command: &ClonableCommand) -> miette::Result<()> {
+    async fn before_startup_shell(command: &ClonableCommand) -> eyre::Result<()> {
         let program = &command.program;
         let mut command = command.as_tokio();
         command.kill_on_drop(true);
@@ -1000,7 +995,6 @@ impl Ghci {
         let status = command
             .status()
             .await
-            .into_diagnostic()
             .wrap_err_with(|| format!("Failed to execute `{command_formatted}`"))?;
         if status.success() {
             tracing::debug!("{program:?} exited successfully: {status}");
@@ -1026,7 +1020,7 @@ impl Ghci {
         compilation_start: Instant,
         log: &mut CompilationLog,
         events: [LifecycleEvent; N],
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         if let Some(error_log_dir) = self.error_log.path().and_then(|path| path.parent()) {
             log.relocate(&self.search_paths.cwd, error_log_dir)?;
         }
@@ -1067,7 +1061,7 @@ impl Ghci {
         &mut self,
         event: LifecycleEvent,
         log: &mut CompilationLog,
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         for hook in self.opts.hooks.select(event) {
             tracing::info!(command = %hook.command, "Running {hook} command");
             match &hook.command {
@@ -1090,7 +1084,7 @@ impl Ghci {
     }
 
     #[instrument(skip(self), level = "trace")]
-    async fn write_error_log(&mut self, log: &CompilationLog) -> miette::Result<()> {
+    async fn write_error_log(&mut self, log: &CompilationLog) -> eyre::Result<()> {
         self.error_log.write(log).await
     }
 }

--- a/src/ghci/parse/eval.rs
+++ b/src/ghci/parse/eval.rs
@@ -2,8 +2,8 @@ use std::collections::VecDeque;
 use std::fmt::Display;
 use std::ops::Range;
 
+use eyre::eyre;
 use line_span::LineSpanExt;
-use miette::miette;
 use winnow::ascii::line_ending;
 use winnow::ascii::space0;
 use winnow::combinator::alt;
@@ -56,10 +56,10 @@ struct ByteSpanCommand {
 }
 
 /// Parse Haskell source file contents into a `Vec` of [`EvalCommand`]s to evaluate on reloads.
-pub fn parse_eval_commands(contents: &str) -> miette::Result<Vec<EvalCommand>> {
+pub fn parse_eval_commands(contents: &str) -> eyre::Result<Vec<EvalCommand>> {
     let mut byte_commands = eval_commands
         .parse(Located::new(contents))
-        .map_err(|err| miette!("{err}"))?;
+        .map_err(|err| eyre!("{err}"))?;
 
     // Convert the byte offsets into line and column numbers.
     //

--- a/src/ghci/parse/ghc_message/mod.rs
+++ b/src/ghci/parse/ghc_message/mod.rs
@@ -4,7 +4,7 @@ use std::fmt::Display;
 
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
-use miette::miette;
+use eyre::eyre;
 use winnow::combinator::alt;
 use winnow::combinator::repeat;
 use winnow::prelude::*;
@@ -145,7 +145,7 @@ impl GhcDiagnostic {
         &mut self,
         old_base: &Utf8Path,
         new_base: &Utf8Path,
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         if let Some(path) = self.path.take() {
             tracing::trace!(
                 %path, %old_base, %new_base,
@@ -187,13 +187,13 @@ impl Display for GhcDiagnostic {
 }
 
 /// Parse [`GhcMessage`]s from lines of compiler output.
-pub fn parse_ghc_messages(lines: &str) -> miette::Result<Vec<GhcMessage>> {
+pub fn parse_ghc_messages(lines: &str) -> eyre::Result<Vec<GhcMessage>> {
     // TODO: Preserve ANSI colors somehow.
     let uncolored_lines = strip_ansi_escapes::strip_str(lines);
 
     parse_messages_inner
         .parse(&uncolored_lines)
-        .map_err(|err| miette!("{err}"))
+        .map_err(|err| eyre!("{err}"))
 }
 
 fn parse_messages_inner(input: &mut &str) -> PResult<Vec<GhcMessage>> {

--- a/src/ghci/parse/lines.rs
+++ b/src/ghci/parse/lines.rs
@@ -92,10 +92,10 @@ mod tests {
 
     #[test]
     fn test_parse_lines_repeat() {
-        fn parser(input: &str) -> miette::Result<Vec<&str>> {
+        fn parser(input: &str) -> eyre::Result<Vec<&str>> {
             repeat(0.., rest_of_line)
                 .parse(input)
-                .map_err(|err| miette::miette!("{err}"))
+                .map_err(|err| eyre::eyre!("{err}"))
         }
 
         assert_eq!(

--- a/src/ghci/parse/module_and_files.rs
+++ b/src/ghci/parse/module_and_files.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
-use miette::miette;
+use eyre::eyre;
 use winnow::ascii::space1;
 use winnow::combinator::repeat;
 use winnow::error::AddContext;
@@ -40,10 +40,10 @@ pub struct CompilingModule {
 }
 
 impl FromStr for CompilingModule {
-    type Err = miette::Report;
+    type Err = eyre::Report;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        module_and_files.parse(s).map_err(|err| miette!("{err}"))
+        module_and_files.parse(s).map_err(|err| eyre!("{err}"))
     }
 }
 

--- a/src/ghci/parse/show_paths.rs
+++ b/src/ghci/parse/show_paths.rs
@@ -2,8 +2,8 @@ use std::collections::HashSet;
 
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
+use eyre::eyre;
 use itertools::Itertools;
-use miette::miette;
 use winnow::ascii::newline;
 use winnow::ascii::space0;
 use winnow::ascii::space1;
@@ -31,7 +31,7 @@ pub struct ShowPaths {
 
 impl ShowPaths {
     /// Convert a target (from `:show targets` output) to a module source path.
-    pub fn target_to_path(&self, target: &str) -> miette::Result<LoadedModule> {
+    pub fn target_to_path(&self, target: &str) -> eyre::Result<LoadedModule> {
         let target_path = Utf8Path::new(target);
         if is_haskell_source_file(target_path) {
             // The target is already a path.
@@ -58,7 +58,7 @@ impl ShowPaths {
                 }
             }
         }
-        Err(miette!("Couldn't find source path for {target}"))
+        Err(eyre!("Couldn't find source path for {target}"))
     }
 
     fn absolute_search_paths(&self) -> impl Iterator<Item = Utf8PathBuf> + '_ {
@@ -72,7 +72,7 @@ impl ShowPaths {
     }
 
     /// Convert a Haskell source path to a module name.
-    pub fn path_to_module(&self, path: &Utf8Path) -> miette::Result<String> {
+    pub fn path_to_module(&self, path: &Utf8Path) -> eyre::Result<String> {
         let path = path.with_extension("");
         let path_str = path.as_str();
 
@@ -89,13 +89,13 @@ impl ShowPaths {
             }
         }
 
-        Err(miette!("Couldn't convert {path} to module name"))
+        Err(eyre!("Couldn't convert {path} to module name"))
     }
 }
 
 /// Parse `:show paths` output into a set of module search paths.
-pub fn parse_show_paths(input: &str) -> miette::Result<ShowPaths> {
-    let mut show_paths = show_paths.parse(input).map_err(|err| miette!("{err}"))?;
+pub fn parse_show_paths(input: &str) -> eyre::Result<ShowPaths> {
+    let mut show_paths = show_paths.parse(input).map_err(|err| eyre!("{err}"))?;
 
     // Deduplicate the search paths.
     show_paths.search_paths = show_paths

--- a/src/ghci/parse/show_targets.rs
+++ b/src/ghci/parse/show_targets.rs
@@ -1,4 +1,4 @@
-use miette::miette;
+use eyre::eyre;
 use winnow::combinator::repeat;
 use winnow::Parser;
 
@@ -8,10 +8,10 @@ use super::lines::until_newline;
 use super::show_paths::ShowPaths;
 
 /// Parse `:show targets` output into a set of module source paths.
-pub fn parse_show_targets(search_paths: &ShowPaths, input: &str) -> miette::Result<ModuleSet> {
+pub fn parse_show_targets(search_paths: &ShowPaths, input: &str) -> eyre::Result<ModuleSet> {
     let targets: Vec<_> = repeat(0.., until_newline)
         .parse(input)
-        .map_err(|err| miette!("{err}"))?;
+        .map_err(|err| eyre!("{err}"))?;
 
     targets
         .into_iter()

--- a/src/ghci/process.rs
+++ b/src/ghci/process.rs
@@ -3,8 +3,7 @@ use std::pin::Pin;
 use std::process::ExitStatus;
 
 use command_group::AsyncGroupChild;
-use miette::Context;
-use miette::IntoDiagnostic;
+use eyre::Context;
 use nix::sys::signal;
 use nix::sys::signal::Signal;
 use nix::unistd::Pid;
@@ -29,7 +28,7 @@ pub struct GhciProcess {
 
 impl GhciProcess {
     #[instrument(skip_all, name = "ghci_process", level = "debug")]
-    pub async fn run(mut self, mut process: AsyncGroupChild) -> miette::Result<()> {
+    pub async fn run(mut self, mut process: AsyncGroupChild) -> eyre::Result<()> {
         // We can only call `wait()` once at a time, so we store the future and pass it into the
         // `stop()` handler.
         let mut wait = std::pin::pin!(process.wait());
@@ -43,7 +42,7 @@ impl GhciProcess {
             }
             result = &mut wait => {
                 tracing::debug!(?result, "ghci exited");
-                let status = result.into_diagnostic()?;
+                let status = result?;
                 self.exited(status).await;
                 let _ = self.exited_sender.send(status).await;
             }
@@ -55,21 +54,19 @@ impl GhciProcess {
     async fn stop(
         &self,
         wait: Pin<&mut impl Future<Output = Result<ExitStatus, std::io::Error>>>,
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         // Kill it otherwise.
         tracing::debug!("Killing ghci process tree with SIGKILL");
         // This is what `self.process.kill()` does, but we can't call that due to borrow
         // checker shennanigans.
-        signal::killpg(self.process_group_id, Signal::SIGKILL)
-            .into_diagnostic()
-            .wrap_err_with(|| {
-                format!(
-                    "Failed to kill ghci process (pid {})",
-                    self.process_group_id
-                )
-            })?;
+        signal::killpg(self.process_group_id, Signal::SIGKILL).wrap_err_with(|| {
+            format!(
+                "Failed to kill ghci process (pid {})",
+                self.process_group_id
+            )
+        })?;
         // Report the exit status.
-        let status = wait.await.into_diagnostic()?;
+        let status = wait.await?;
 
         self.exited(status).await;
         Ok(())

--- a/src/ghci/stderr.rs
+++ b/src/ghci/stderr.rs
@@ -3,8 +3,7 @@ use std::time::Instant;
 
 use backoff::backoff::Backoff;
 use backoff::ExponentialBackoff;
-use miette::Context;
-use miette::IntoDiagnostic;
+use eyre::Context;
 use tokio::io::AsyncWriteExt;
 use tokio::io::BufReader;
 use tokio::io::Lines;
@@ -38,7 +37,7 @@ pub struct GhciStderr {
 
 impl GhciStderr {
     #[instrument(skip_all, name = "stderr", level = "debug")]
-    pub async fn run(mut self) -> miette::Result<()> {
+    pub async fn run(mut self) -> eyre::Result<()> {
         let mut backoff = ExponentialBackoff::default();
         while let Some(duration) = backoff.next_backoff() {
             match self.run_inner().await {
@@ -58,7 +57,7 @@ impl GhciStderr {
         Ok(())
     }
 
-    pub async fn run_inner(&mut self) -> miette::Result<()> {
+    pub async fn run_inner(&mut self) -> eyre::Result<()> {
         loop {
             tokio::select! {
                 Ok(Some(line)) = self.reader.next_line() => {
@@ -80,7 +79,7 @@ impl GhciStderr {
         Ok(())
     }
 
-    async fn dispatch(&mut self, event: StderrEvent) -> miette::Result<()> {
+    async fn dispatch(&mut self, event: StderrEvent) -> eyre::Result<()> {
         match event {
             StderrEvent::ClearBuffer => {
                 self.clear_buffer().await;
@@ -94,14 +93,11 @@ impl GhciStderr {
     }
 
     #[instrument(skip(self), level = "trace")]
-    async fn ingest_line(&mut self, mut line: String) -> miette::Result<()> {
+    async fn ingest_line(&mut self, mut line: String) -> eyre::Result<()> {
         tracing::debug!(line, "Read stderr line");
         line.push('\n');
         self.buffer.push_str(&line);
-        self.writer
-            .write_all(line.as_bytes())
-            .await
-            .into_diagnostic()?;
+        self.writer.write_all(line.as_bytes()).await?;
         Ok(())
     }
 
@@ -111,7 +107,7 @@ impl GhciStderr {
     }
 
     #[instrument(skip(self, sender), level = "debug")]
-    async fn get_buffer(&mut self, sender: oneshot::Sender<String>) -> miette::Result<()> {
+    async fn get_buffer(&mut self, sender: oneshot::Sender<String>) -> eyre::Result<()> {
         // Read lines from the stderr stream until we can't read a line within 0.05 seconds.
         //
         // This helps make sure we've read all the available data.
@@ -121,10 +117,7 @@ impl GhciStderr {
         while let Ok(maybe_line) =
             tokio::time::timeout(Duration::from_millis(50), self.reader.next_line()).await
         {
-            match maybe_line
-                .into_diagnostic()
-                .wrap_err("Failed to read stderr line")?
-            {
+            match maybe_line.wrap_err("Failed to read stderr line")? {
                 Some(line) => {
                     self.ingest_line(line).await?;
                 }

--- a/src/ghci/stdin.rs
+++ b/src/ghci/stdin.rs
@@ -1,6 +1,5 @@
+use eyre::Context;
 use itertools::Itertools;
-use miette::Context;
-use miette::IntoDiagnostic;
 use tokio::io::AsyncWriteExt;
 use tokio::process::ChildStdin;
 use tracing::instrument;
@@ -33,11 +32,8 @@ impl GhciStdin {
         line: &str,
         find: FindAt,
         log: &mut CompilationLog,
-    ) -> miette::Result<()> {
-        self.stdin
-            .write_all(line.as_bytes())
-            .await
-            .into_diagnostic()?;
+    ) -> eyre::Result<()> {
+        self.stdin.write_all(line.as_bytes()).await?;
         stdout.prompt(find, log).await
     }
 
@@ -49,7 +45,7 @@ impl GhciStdin {
         stdout: &mut GhciStdout,
         line: &str,
         log: &mut CompilationLog,
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         self.write_line_with_prompt_at(stdout, line, FindAt::LineStart, log)
             .await
     }
@@ -63,7 +59,7 @@ impl GhciStdin {
         stdout: &mut GhciStdout,
         command: &GhciCommand,
         log: &mut CompilationLog,
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         for line in command.lines() {
             self.write_line(stdout, &format!("{line}\n"), log).await?;
         }
@@ -75,11 +71,11 @@ impl GhciStdin {
     ///
     /// Callers that need to wait for GHCi to acknowledge the new prompt should use
     /// [`Self::set_prompt`] instead.
-    pub async fn write_set_prompt(&mut self, prompt: &str) -> miette::Result<()> {
+    pub async fn write_set_prompt(&mut self, prompt: &str) -> eyre::Result<()> {
         self.stdin
             .write_all(format!(":set prompt \"{prompt}\"\n").as_bytes())
-            .await
-            .into_diagnostic()
+            .await?;
+        Ok(())
     }
 
     /// Set the GHCi prompt to the given string.
@@ -92,7 +88,7 @@ impl GhciStdin {
         prompt: &str,
         find: FindAt,
         log: &mut CompilationLog,
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         self.write_set_prompt(prompt).await?;
         stdout.prompt(find, log).await
     }
@@ -102,7 +98,7 @@ impl GhciStdin {
         &mut self,
         stdout: &mut GhciStdout,
         log: &mut CompilationLog,
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         // We tell stdout/stderr we're compiling for the first prompt because this includes all the
         // module compilation before the first prompt.
         self.set_prompt(stdout, PROMPT, FindAt::Anywhere, log)
@@ -117,7 +113,7 @@ impl GhciStdin {
         &mut self,
         stdout: &mut GhciStdout,
         log: &mut CompilationLog,
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         self.write_line(stdout, ":reload\n", log).await
     }
 
@@ -127,7 +123,7 @@ impl GhciStdin {
         stdout: &mut GhciStdout,
         modules: impl IntoIterator<Item = &LoadedModule>,
         log: &mut CompilationLog,
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         let modules = modules.into_iter().format(" ");
         // We use `:add` because `:load` unloads all previously loaded modules:
         //
@@ -146,7 +142,7 @@ impl GhciStdin {
         stdout: &mut GhciStdout,
         modules: impl IntoIterator<Item = &LoadedModule>,
         log: &mut CompilationLog,
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         let modules = modules.into_iter().format(" ");
         self.write_line(stdout, &format!(":unadd {modules}\n"), log)
             .await
@@ -158,7 +154,7 @@ impl GhciStdin {
         stdout: &mut GhciStdout,
         module: &LoadedModule,
         log: &mut CompilationLog,
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         // `:add *` forces the module to be interpreted, even if it was already loaded from
         // bytecode. This is necessary to access the module's top-level binds for the eval feature.
         self.write_line(stdout, &format!(":add *{module}\n"), log)
@@ -172,7 +168,7 @@ impl GhciStdin {
         module_name: &str,
         command: &GhciCommand,
         log: &mut CompilationLog,
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         self.write_line(stdout, &format!(":module + *{module_name}\n"), log)
             .await?;
 
@@ -185,11 +181,8 @@ impl GhciStdin {
     }
 
     #[instrument(skip(self, stdout), level = "debug")]
-    pub async fn show_paths(&mut self, stdout: &mut GhciStdout) -> miette::Result<ShowPaths> {
-        self.stdin
-            .write_all(b":show paths\n")
-            .await
-            .into_diagnostic()?;
+    pub async fn show_paths(&mut self, stdout: &mut GhciStdout) -> eyre::Result<ShowPaths> {
+        self.stdin.write_all(b":show paths\n").await?;
 
         stdout.show_paths().await
     }
@@ -199,22 +192,18 @@ impl GhciStdin {
         &mut self,
         stdout: &mut GhciStdout,
         show_paths: &ShowPaths,
-    ) -> miette::Result<ModuleSet> {
-        self.stdin
-            .write_all(b":show targets\n")
-            .await
-            .into_diagnostic()?;
+    ) -> eyre::Result<ModuleSet> {
+        self.stdin.write_all(b":show targets\n").await?;
 
         stdout.show_targets(show_paths).await
     }
 
     #[allow(dead_code)] // TODO: No it should not be!
     #[instrument(skip(self, stdout), level = "debug")]
-    pub async fn quit(&mut self, stdout: &mut GhciStdout) -> miette::Result<()> {
+    pub async fn quit(&mut self, stdout: &mut GhciStdout) -> eyre::Result<()> {
         self.stdin
             .write_all(b":quit\n")
             .await
-            .into_diagnostic()
             .wrap_err("Failed to tell ghci to `:quit`")?;
         stdout
             .quit()

--- a/src/ghci/stdout.rs
+++ b/src/ghci/stdout.rs
@@ -1,8 +1,7 @@
 use std::time::Duration;
 
 use aho_corasick::AhoCorasick;
-use miette::Context;
-use miette::IntoDiagnostic;
+use eyre::Context;
 use tokio::process::ChildStdout;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
@@ -37,7 +36,7 @@ pub struct GhciStdout {
 
 impl GhciStdout {
     #[instrument(skip_all, level = "debug")]
-    async fn parse_into_log(&self, data: &str, log: &mut CompilationLog) -> miette::Result<()> {
+    async fn parse_into_log(&self, data: &str, log: &mut CompilationLog) -> eyre::Result<()> {
         // Parse GHCi output into compiler messages.
         //
         // These include diagnostics, which modules were compiled, and a compilation summary.
@@ -47,7 +46,7 @@ impl GhciStdout {
                 .stderr_sender
                 .send(StderrEvent::GetBuffer { sender })
                 .await;
-            receiver.await.into_diagnostic()?
+            receiver.await?
         };
         log.extend(parse_ghc_messages(data).wrap_err("Failed to parse compiler output")?);
         log.extend(parse_ghc_messages(&stderr_data).wrap_err("Failed to parse compiler output")?);
@@ -55,7 +54,7 @@ impl GhciStdout {
     }
 
     #[instrument(skip_all, name = "stdout_initialize", level = "debug")]
-    pub async fn initialize(&mut self, log: &mut CompilationLog) -> miette::Result<()> {
+    pub async fn initialize(&mut self, log: &mut CompilationLog) -> eyre::Result<()> {
         // Wait for `ghci` to start up. This may involve compiling a bunch of stuff.
         let bootup_patterns = AhoCorasick::from_anchored_patterns([
             "GHCi, version ",
@@ -79,11 +78,8 @@ impl GhciStdout {
     }
 
     #[instrument(skip_all, level = "debug")]
-    pub async fn prompt(&mut self, find: FindAt, log: &mut CompilationLog) -> miette::Result<()> {
-        self.stderr_sender
-            .send(StderrEvent::ClearBuffer)
-            .await
-            .into_diagnostic()?;
+    pub async fn prompt(&mut self, find: FindAt, log: &mut CompilationLog) -> eyre::Result<()> {
+        self.stderr_sender.send(StderrEvent::ClearBuffer).await?;
 
         let data = self
             .reader
@@ -102,7 +98,7 @@ impl GhciStdout {
 
     /// Read any immediately-available output from the pipe, then drain stale prompts from
     /// the internal buffer. Returns the number of prompts found and discarded.
-    pub async fn buffer_and_drain_prompts(&mut self, timeout: Duration) -> miette::Result<usize> {
+    pub async fn buffer_and_drain_prompts(&mut self, timeout: Duration) -> eyre::Result<usize> {
         self.reader
             .buffer_available(&mut self.buffer, timeout, WriteBehavior::NoFinalLine)
             .await?;
@@ -122,7 +118,7 @@ impl GhciStdout {
     /// Used by `send_sigint` to synchronize with GHCi after an interrupt: a sync expression
     /// is sent on stdin and this method reads until its output appears, guaranteeing that all
     /// prior output has been consumed.
-    pub async fn read_until_marker(&mut self, marker: &str) -> miette::Result<String> {
+    pub async fn read_until_marker(&mut self, marker: &str) -> eyre::Result<String> {
         let pattern = AhoCorasick::from_anchored_patterns([marker]);
         self.reader
             .read_until(&mut ReadOpts {
@@ -135,7 +131,7 @@ impl GhciStdout {
     }
 
     #[instrument(skip_all, level = "debug")]
-    pub async fn show_paths(&mut self) -> miette::Result<ShowPaths> {
+    pub async fn show_paths(&mut self) -> eyre::Result<ShowPaths> {
         let lines = self
             .reader
             .read_until(&mut ReadOpts {
@@ -149,7 +145,7 @@ impl GhciStdout {
     }
 
     #[instrument(skip_all, level = "debug")]
-    pub async fn show_targets(&mut self, search_paths: &ShowPaths) -> miette::Result<ModuleSet> {
+    pub async fn show_targets(&mut self, search_paths: &ShowPaths) -> eyre::Result<ModuleSet> {
         let lines = self
             .reader
             .read_until(&mut ReadOpts {
@@ -164,7 +160,7 @@ impl GhciStdout {
 
     #[allow(dead_code)] // TODO: No it should not be!
     #[instrument(skip_all, level = "debug")]
-    pub async fn quit(&mut self) -> miette::Result<()> {
+    pub async fn quit(&mut self) -> eyre::Result<()> {
         let leaving_ghci = AhoCorasick::from_anchored_patterns(["Leaving GHCi."]);
         let data = self
             .reader

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -311,8 +311,8 @@ impl HookOpts {
     pub async fn run_shell_hooks(
         &self,
         event: LifecycleEvent,
-        handles: &mut Vec<JoinHandle<miette::Result<ExitStatus>>>,
-    ) -> miette::Result<()> {
+        handles: &mut Vec<JoinHandle<eyre::Result<ExitStatus>>>,
+    ) -> eyre::Result<()> {
         for hook in self.select(event) {
             if let Command::Shell(command) = &hook.command {
                 tracing::info!(%command, "Running {hook} command");

--- a/src/ignore.rs
+++ b/src/ignore.rs
@@ -2,12 +2,11 @@
 
 use std::path::Path;
 
+use eyre::Context;
 use ignore::gitignore::Gitignore;
 use ignore::gitignore::GitignoreBuilder;
 use ignore::gitignore::Glob;
 use ignore::Match;
-use miette::Context;
-use miette::IntoDiagnostic;
 
 /// A matcher against sets of globs, `.gitignore` style.
 ///
@@ -27,20 +26,18 @@ impl GlobMatcher {
     /// the last matching pattern decides the match outcome.
     ///
     /// [gitignore]: https://www.man7.org/linux/man-pages/man5/gitignore.5.html
-    pub fn from_globs(globs: impl IntoIterator<Item = impl AsRef<str>>) -> miette::Result<Self> {
+    pub fn from_globs(globs: impl IntoIterator<Item = impl AsRef<str>>) -> eyre::Result<Self> {
         let mut builder = GitignoreBuilder::new(crate::current_dir()?);
 
         for glob in globs {
             let glob = glob.as_ref();
             builder
                 .add_line(None, glob)
-                .into_diagnostic()
                 .wrap_err_with(|| format!("Failed to compile glob: {glob:?}"))?;
         }
 
         builder
             .build()
-            .into_diagnostic()
             .wrap_err("Failed to compile glob matcher")
             .map(Self)
     }

--- a/src/incremental_reader.rs
+++ b/src/incremental_reader.rs
@@ -6,7 +6,6 @@ use std::time::Duration;
 
 use aho_corasick::AhoCorasick;
 use line_span::LineSpans;
-use miette::IntoDiagnostic;
 use tokio::io::AsyncRead;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWrite;
@@ -81,7 +80,7 @@ where
     ///
     /// TODO: Should this even use `aho_corasick`? Might be overkill, and with the automaton
     /// construction cost it might not even be more efficient.
-    pub async fn read_until(&mut self, opts: &mut ReadOpts<'_>) -> miette::Result<String> {
+    pub async fn read_until(&mut self, opts: &mut ReadOpts<'_>) -> eyre::Result<String> {
         loop {
             if let Some(lines) = self.try_read_until(opts).await? {
                 return Ok(lines);
@@ -92,7 +91,7 @@ where
     /// Examines the internal buffer and reads at most once from the underlying reader. If a line
     /// beginning with one of the `end_marker` patterns is seen, the lines before the marker are
     /// returned. Otherwise, nothing is returned.
-    async fn try_read_until(&mut self, opts: &mut ReadOpts<'_>) -> miette::Result<Option<String>> {
+    async fn try_read_until(&mut self, opts: &mut ReadOpts<'_>) -> eyre::Result<Option<String>> {
         self.drain_pending(opts.writing).await?;
 
         if let Some(chunk) = self.take_chunk_from_buffer(opts) {
@@ -124,7 +123,7 @@ where
                     }
                 }
             }
-            Err(err) => Err(err).into_diagnostic(),
+            Err(err) => Err(err.into()),
         }
     }
 
@@ -182,7 +181,7 @@ where
         buffer: &mut [u8],
         timeout: Duration,
         writing: WriteBehavior,
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         match tokio::time::timeout(timeout, async {
             loop {
                 match self.reader.read(buffer).await {
@@ -191,7 +190,7 @@ where
                         let decoded = self.decode(&buffer[..n]);
                         self.buffer_decoded(&decoded, writing).await?;
                     }
-                    Err(err) => return Err(err).into_diagnostic(),
+                    Err(err) => return Err(eyre::Report::from(err)),
                 }
             }
         })
@@ -206,7 +205,7 @@ where
     /// markers.
     ///
     /// Cancel-safe: data is pushed to `self.pending` synchronously before any `.await`.
-    async fn buffer_decoded(&mut self, data: &str, writing: WriteBehavior) -> miette::Result<()> {
+    async fn buffer_decoded(&mut self, data: &str, writing: WriteBehavior) -> eyre::Result<()> {
         self.pending.push_str(data);
         self.drain_pending(writing).await
     }
@@ -219,7 +218,7 @@ where
     ///
     /// Cancel-safe: if dropped mid-processing, unprocessed data remains in `self.pending`
     /// and will be drained on the next call.
-    async fn drain_pending(&mut self, writing: WriteBehavior) -> miette::Result<()> {
+    async fn drain_pending(&mut self, writing: WriteBehavior) -> eyre::Result<()> {
         loop {
             let Some(newline_idx) = self.pending.find('\n') else {
                 break;
@@ -246,7 +245,7 @@ where
         &mut self,
         mut data: &str,
         opts: &ReadOpts<'_>,
-    ) -> miette::Result<Option<String>> {
+    ) -> eyre::Result<Option<String>> {
         // Proof of this function's corectness: just trust me
 
         let mut ret = None;
@@ -323,16 +322,13 @@ where
     }
 
     /// Clears `self.lines` and `self.line`, returning the previous value of `self.lines`.
-    async fn take_lines(&mut self, writing: WriteBehavior) -> miette::Result<String> {
+    async fn take_lines(&mut self, writing: WriteBehavior) -> eyre::Result<String> {
         if let Some(writer) = &mut self.writer {
             match writing {
                 WriteBehavior::Write => {
-                    writer
-                        .write_all(self.line.as_bytes())
-                        .await
-                        .into_diagnostic()?;
+                    writer.write_all(self.line.as_bytes()).await?;
                     // We'll just pretend this is the end of the line...
-                    writer.write_all(b"\n").await.into_diagnostic()?;
+                    writer.write_all(b"\n").await?;
                 }
                 WriteBehavior::NoFinalLine | WriteBehavior::Hide => {}
             }
@@ -346,15 +342,12 @@ where
     }
 
     /// Add `self.line` to `self.lines`, replacing `self.line` with an empty buffer.
-    async fn finish_line(&mut self, writing: WriteBehavior) -> miette::Result<()> {
+    async fn finish_line(&mut self, writing: WriteBehavior) -> eyre::Result<()> {
         if let Some(writer) = &mut self.writer {
             match writing {
                 WriteBehavior::Write | WriteBehavior::NoFinalLine => {
-                    writer
-                        .write_all(self.line.as_bytes())
-                        .await
-                        .into_diagnostic()?;
-                    writer.write_all(b"\n").await.into_diagnostic()?;
+                    writer.write_all(self.line.as_bytes()).await?;
+                    writer.write_all(b"\n").await?;
                 }
                 WriteBehavior::Hide => {}
             }
@@ -418,7 +411,7 @@ where
     ///
     /// This is used after `send_sigint` to discard stale prompts left behind by an aborted
     /// `prompt()` call. Returns the number of chunks drained.
-    pub async fn drain_buffered_chunks(&mut self, opts: &ReadOpts<'_>) -> miette::Result<usize> {
+    pub async fn drain_buffered_chunks(&mut self, opts: &ReadOpts<'_>) -> eyre::Result<usize> {
         self.drain_pending(opts.writing).await?;
         let mut count = 0;
         while self.take_chunk_from_buffer(opts).is_some() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 
 use clap::CommandFactory;
 use clap::Parser;
+use eyre::eyre;
 use ghciwatch::cli;
 use ghciwatch::cli::ExperimentalFeature;
 use ghciwatch::run_ghci;
@@ -17,17 +18,16 @@ use ghciwatch::GhciOpts;
 use ghciwatch::ShutdownManager;
 use ghciwatch::TracingOpts;
 use ghciwatch::WatcherOpts;
-use miette::miette;
 use tokio::sync::mpsc;
 
 #[tokio::main]
-async fn main() -> miette::Result<()> {
-    miette::set_panic_hook();
+async fn main() -> eyre::Result<()> {
+    color_eyre::install()?;
     let mut opts = cli::Opts::parse();
     opts.init()?;
 
     if opts.tui {
-        return Err(miette!(
+        return Err(eyre!(
             "`--tui` has been removed. Please use `--experimental-features tui` instead."
         ));
     }
@@ -48,13 +48,10 @@ async fn main() -> miette::Result<()> {
 
     #[cfg(feature = "clap_mangen")]
     if let Some(out_dir) = opts.generate_man_pages {
-        use miette::IntoDiagnostic;
-        use miette::WrapErr;
+        use eyre::WrapErr;
 
         let command = cli::Opts::command();
-        clap_mangen::generate_to(command, out_dir)
-            .into_diagnostic()
-            .wrap_err("Failed to generate man pages")?;
+        clap_mangen::generate_to(command, out_dir).wrap_err("Failed to generate man pages")?;
         return Ok(());
     }
 

--- a/src/maybe_async_command.rs
+++ b/src/maybe_async_command.rs
@@ -4,9 +4,8 @@ use std::process::ExitStatus;
 use std::process::Stdio;
 use std::str::FromStr;
 
-use miette::miette;
-use miette::Context;
-use miette::IntoDiagnostic;
+use eyre::eyre;
+use eyre::Context;
 use tokio::task::JoinHandle;
 use tracing::instrument;
 use tracing::Instrument;
@@ -34,12 +33,12 @@ impl Display for MaybeAsyncCommand {
 }
 
 impl FromStr for MaybeAsyncCommand {
-    type Err = miette::Report;
+    type Err = eyre::Report;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         parse_maybe_async_command
             .parse(s)
-            .map_err(|err| miette!("{err}"))
+            .map_err(|err| eyre!("{err}"))
     }
 }
 
@@ -65,7 +64,6 @@ impl MaybeAsyncCommand {
                     .stderr(Stdio::piped())
                     .output()
                     .await
-                    .into_diagnostic()
                     .wrap_err_with(|| format!("Failed to execute `{command_formatted}`"))?;
 
                 let status = output.status;
@@ -109,7 +107,6 @@ impl MaybeAsyncCommand {
             let command_formatted = self.display();
             let status = join_handle
                 .await
-                .into_diagnostic()
                 .wrap_err_with(|| format!("Panicked while executing `{command_formatted}`"))
                 .and_then(std::convert::identity);
             MaybeAsyncCommandStatus::Sync(status)
@@ -122,8 +119,8 @@ impl MaybeAsyncCommand {
     /// task to the given list of handles.
     pub async fn run_on(
         &self,
-        handles: &mut Vec<JoinHandle<miette::Result<ExitStatus>>>,
-    ) -> miette::Result<()> {
+        handles: &mut Vec<JoinHandle<eyre::Result<ExitStatus>>>,
+    ) -> eyre::Result<()> {
         match self.status().await {
             MaybeAsyncCommandStatus::Sync(result) => {
                 // If we failed to execute the program, that's an actual error, but if the
@@ -141,8 +138,8 @@ impl MaybeAsyncCommand {
 }
 
 pub enum MaybeAsyncCommandStatus {
-    Sync(miette::Result<ExitStatus>),
-    Async(JoinHandle<miette::Result<ExitStatus>>),
+    Sync(eyre::Result<ExitStatus>),
+    Async(JoinHandle<eyre::Result<ExitStatus>>),
 }
 
 impl CommandExt for MaybeAsyncCommand {

--- a/src/normal_path.rs
+++ b/src/normal_path.rs
@@ -10,8 +10,7 @@ use camino::Utf8PathBuf;
 use clap::builder::PathBufValueParser;
 use clap::builder::TypedValueParser;
 use clap::builder::ValueParserFactory;
-use miette::miette;
-use miette::IntoDiagnostic;
+use eyre::eyre;
 use path_absolutize::Absolutize;
 
 /// A normalized [`Utf8PathBuf`] in tandem with a relative path.
@@ -31,27 +30,27 @@ pub struct NormalPath {
 
 impl NormalPath {
     /// Creates a new normalized path relative to the given base path.
-    pub fn new(original: impl AsRef<Path>, base: impl AsRef<Path>) -> miette::Result<Self> {
+    pub fn new(original: impl AsRef<Path>, base: impl AsRef<Path>) -> eyre::Result<Self> {
         let base = base.as_ref();
-        let normal = original.as_ref().absolutize_from(base).into_diagnostic()?;
+        let normal = original.as_ref().absolutize_from(base)?;
         let normal = normal
             .into_owned()
             .try_into()
-            .map_err(|err| miette!("{err}"))?;
+            .map_err(|err| eyre!("{err}"))?;
         let relative = match pathdiff::diff_paths(&normal, base) {
-            Some(path) => Some(path.try_into().map_err(|err| miette!("{err}"))?),
+            Some(path) => Some(path.try_into().map_err(|err| eyre!("{err}"))?),
             None => None,
         };
         Ok(Self { normal, relative })
     }
 
     /// Create a new normalized path relative to the current working directory.
-    pub fn from_cwd(original: impl AsRef<Path>) -> miette::Result<Self> {
+    pub fn from_cwd(original: impl AsRef<Path>) -> eyre::Result<Self> {
         Self::new(original, crate::current_dir()?)
     }
 
     /// Relocate this path to be relative to a different base directory.
-    pub fn relocate(&self, new_base: impl AsRef<Path>) -> miette::Result<Self> {
+    pub fn relocate(&self, new_base: impl AsRef<Path>) -> eyre::Result<Self> {
         Self::new(self.absolute(), new_base)
     }
 

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -8,8 +8,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 
-use miette::miette;
-use miette::IntoDiagnostic;
+use eyre::eyre;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
@@ -65,7 +64,7 @@ impl ShutdownManager {
     where
         S: Into<String>,
         F: FnOnce(ShutdownHandle) -> Fut,
-        Fut: Future<Output = miette::Result<()>> + Send + 'static,
+        Fut: Future<Output = eyre::Result<()>> + Send + 'static,
     {
         let sender = self.sender.clone();
         let receiver = sender.subscribe();
@@ -82,7 +81,7 @@ impl ShutdownManager {
 
     /// Wait for tasks to shut down/error or Ctrl-C to be pressed and then shuts down gracefully.
     #[instrument(level = "debug", skip_all)]
-    pub async fn wait_for_shutdown(mut self) -> miette::Result<()> {
+    pub async fn wait_for_shutdown(mut self) -> eyre::Result<()> {
         drop(self.guard_sender);
         let mut all_finished = false;
 
@@ -91,7 +90,7 @@ impl ShutdownManager {
             _ = tokio::signal::ctrl_c() => {
                 tracing::debug!("Ctrl-C pressed, shutting down gracefully");
                 // Note that we need to trigger the shutdown manually in this case.
-                self.sender.send(()).into_diagnostic()?;
+                self.sender.send(())?;
             }
             _ = self.guard_receiver.recv() => {
                 tracing::debug!("All tasks finished");
@@ -148,7 +147,7 @@ impl Handles {
     }
 
     #[instrument(level = "debug", skip_all)]
-    async fn check_task_failures(&mut self) -> miette::Result<()> {
+    async fn check_task_failures(&mut self) -> eyre::Result<()> {
         let mut failures = Vec::new();
 
         for task in std::mem::take(self.0.lock().await.deref_mut()) {
@@ -173,7 +172,7 @@ impl Handles {
                     .into_iter()
                     .map(|(name, error)| format!("{name}: {error}")),
             );
-            Err(miette!("Tasks failed:\n{failures}"))
+            Err(eyre!("Tasks failed:\n{failures}"))
         }
     }
 }
@@ -215,14 +214,14 @@ impl ShutdownHandle {
     /// Check if a shutdown has been requested; if so, return a [`ShutdownError`].
     ///
     /// Otherwise, return `Ok(())`.
-    pub fn error_if_shutdown_requested(&mut self) -> miette::Result<()> {
+    pub fn error_if_shutdown_requested(&mut self) -> eyre::Result<()> {
         match self.receiver.try_recv() {
             Ok(()) | Err(broadcast::error::TryRecvError::Lagged(_)) => Err(ShutdownError.into()),
             Err(broadcast::error::TryRecvError::Empty) => {
                 // No shutdown requested.
                 Ok(())
             }
-            err @ Err(broadcast::error::TryRecvError::Closed) => err.into_diagnostic(),
+            Err(err @ broadcast::error::TryRecvError::Closed) => Err(err.into()),
         }
     }
 
@@ -237,7 +236,7 @@ impl ShutdownHandle {
     where
         S: Into<String>,
         F: FnOnce(ShutdownHandle) -> Fut,
-        Fut: Future<Output = miette::Result<()>> + Send + 'static,
+        Fut: Future<Output = eyre::Result<()>> + Send + 'static,
     {
         let handle = tokio::task::spawn(make_task(self.clone()));
         self.handles
@@ -254,7 +253,7 @@ struct Task {
     /// A handle for remotely cancelling the task.
     abort_handle: AbortHandle,
     /// A receiver for the task's return value.
-    receiver: oneshot::Receiver<Option<miette::Report>>,
+    receiver: oneshot::Receiver<Option<eyre::Report>>,
     /// A handle for the manager which runs asynchronously and requests a shutdown if the task
     /// errors.
     #[allow(dead_code)]
@@ -265,7 +264,7 @@ impl Task {
     /// Create a new task with the given name and handle.
     fn new(
         name: String,
-        handle: JoinHandle<miette::Result<()>>,
+        handle: JoinHandle<eyre::Result<()>>,
         request_shutdown: broadcast::Sender<()>,
     ) -> Self {
         let abort_handle = handle.abort_handle();
@@ -295,8 +294,8 @@ impl Task {
     }
 
     /// Wait for the task to complete and get its name and an error message if it fails.
-    async fn into_result(self) -> miette::Result<Option<(String, miette::ErrReport)>> {
-        let maybe_error = self.receiver.await.into_diagnostic()?;
+    async fn into_result(self) -> eyre::Result<Option<(String, eyre::ErrReport)>> {
+        let maybe_error = self.receiver.await?;
         Ok(maybe_error.map(|err| (self.name, err)))
     }
 }
@@ -304,9 +303,9 @@ impl Task {
 /// Manage a task, requesting a shutdown if it fails and notifying the given sender of any errors.
 async fn manage_handle(
     name: String,
-    handle: JoinHandle<miette::Result<()>>,
+    handle: JoinHandle<eyre::Result<()>>,
     request_shutdown: broadcast::Sender<()>,
-    sender: oneshot::Sender<Option<miette::Report>>,
+    sender: oneshot::Sender<Option<eyre::Report>>,
 ) {
     let mut ret = None;
     match handle.await {
@@ -326,7 +325,7 @@ async fn manage_handle(
                 tracing::debug!(task = name, "Task cancelled");
             } else {
                 tracing::debug!(task = name, "Task panicked: {err}");
-                ret = Some(miette!("{err}"));
+                ret = Some(eyre!("{err}"));
             }
         }
     }
@@ -346,9 +345,9 @@ async fn manage_handle(
 pub struct ShutdownError;
 
 impl ShutdownError {
-    /// Get a [`miette::Report`] of a [`ShutdownError`].
-    pub fn as_report() -> miette::Report {
-        miette::Report::msg(Self)
+    /// Get a [`eyre::Report`] of a [`ShutdownError`].
+    pub fn as_report() -> eyre::Report {
+        eyre::Report::msg(Self)
     }
 }
 
@@ -359,5 +358,3 @@ impl Display for ShutdownError {
         write!(f, "Shutdown requested")
     }
 }
-
-impl miette::Diagnostic for ShutdownError {}

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -2,8 +2,7 @@
 use std::io::Write;
 
 use camino::Utf8Path;
-use miette::Context;
-use miette::IntoDiagnostic;
+use eyre::Context;
 use tokio::io::DuplexStream;
 use tokio_util::io::SyncIoBridge;
 use tracing_appender::non_blocking::WorkerGuard;
@@ -53,8 +52,8 @@ impl<'opts> TracingOpts<'opts> {
     }
 
     /// Initialize the [`tracing`] logging framework.
-    pub fn install(&mut self) -> miette::Result<(Option<DuplexStream>, WorkerGuard)> {
-        let env_filter = EnvFilter::try_new(self.filter_directives).into_diagnostic()?;
+    pub fn install(&mut self) -> eyre::Result<(Option<DuplexStream>, WorkerGuard)> {
+        let env_filter = EnvFilter::try_new(self.filter_directives)?;
 
         let fmt_span = self
             .trace_spans
@@ -106,15 +105,14 @@ fn tracing_json_layer<S>(
     filter_directives: &str,
     log_path: &Utf8Path,
     fmt_span: FmtSpan,
-) -> miette::Result<Box<dyn tracing_subscriber::Layer<S> + Send + Sync + 'static>>
+) -> eyre::Result<Box<dyn tracing_subscriber::Layer<S> + Send + Sync + 'static>>
 where
     S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
 {
-    let file = std::fs::File::create(log_path)
-        .into_diagnostic()
-        .wrap_err_with(|| format!("Failed to open {log_path:?}"))?;
+    let file =
+        std::fs::File::create(log_path).wrap_err_with(|| format!("Failed to open {log_path:?}"))?;
 
-    let env_filter = EnvFilter::try_new(filter_directives).into_diagnostic()?;
+    let env_filter = EnvFilter::try_new(filter_directives)?;
 
     let layer = fmt::layer()
         .with_span_events(fmt_span)

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -7,9 +7,8 @@ use crossterm::event::EventStream;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyModifiers;
 use crossterm::event::MouseEventKind;
-use miette::miette;
-use miette::IntoDiagnostic;
-use miette::WrapErr;
+use eyre::eyre;
+use eyre::WrapErr;
 use ratatui::prelude::Buffer;
 use ratatui::prelude::Constraint;
 use ratatui::prelude::Layout;
@@ -57,7 +56,7 @@ impl Default for TuiState {
 
 impl TuiState {
     #[instrument(level = "trace", skip_all)]
-    fn render_inner(&self, area: Rect, buffer: &mut Buffer) -> miette::Result<()> {
+    fn render_inner(&self, area: Rect, buffer: &mut Buffer) -> eyre::Result<()> {
         if area.width == 0 || area.height == 0 {
             return Ok(());
         }
@@ -68,10 +67,9 @@ impl TuiState {
         ])
         .split(area);
 
-        let text = self.scrollback.into_text().into_diagnostic()?;
+        let text = self.scrollback.into_text()?;
 
         let scroll_offset = u16::try_from(self.scroll_offset.0)
-            .into_diagnostic()
             .wrap_err("Scroll offset doesn't fit into 16 bits")?;
 
         Paragraph::new(text)
@@ -165,7 +163,7 @@ impl Tui {
     }
 
     #[instrument(level = "trace", skip(self))]
-    fn render(&mut self) -> miette::Result<()> {
+    fn render(&mut self) -> eyre::Result<()> {
         let mut render_result = Ok(());
         self.terminal
             .draw(|frame| {
@@ -173,14 +171,13 @@ impl Tui {
                 let buffer = frame.buffer_mut();
                 render_result = self.state.render_inner(self.size, buffer);
             })
-            .into_diagnostic()
             .wrap_err("Failed to draw to terminal")?;
 
         Ok(())
     }
 
     #[instrument(level = "trace", skip(self))]
-    fn handle_event(&mut self, event: Event) -> miette::Result<()> {
+    fn handle_event(&mut self, event: Event) -> eyre::Result<()> {
         // TODO: Steal Evan's declarative key matching macros?
         // https://github.com/evanrelf/indigo/blob/7a5e8e47291585cae03cdf5a7c47ad3bcd8db3e6/crates/indigo-tui/src/key/macros.rs
         match event {
@@ -218,7 +215,7 @@ pub async fn run_tui(
     mut shutdown: ShutdownHandle,
     ghci_reader: DuplexStream,
     tracing_reader: DuplexStream,
-) -> miette::Result<()> {
+) -> eyre::Result<()> {
     let mut ghci_reader = BufReader::new(ghci_reader).lines();
     let mut tracing_reader = BufReader::new(tracing_reader).lines();
 
@@ -236,7 +233,7 @@ pub async fn run_tui(
             }
 
             line = ghci_reader.next_line() => {
-                let line = line.into_diagnostic().wrap_err("Failed to read line from GHCI")?;
+                let line = line.wrap_err("Failed to read line from GHCI")?;
                 match line {
                     Some(line) => {
                         tui.push_line(line);
@@ -248,7 +245,7 @@ pub async fn run_tui(
             }
 
             line = tracing_reader.next_line() => {
-                let line = line.into_diagnostic().wrap_err("Failed to read line from tracing")?;
+                let line = line.wrap_err("Failed to read line from tracing")?;
                 if let Some(line) = line {
                     tui.push_line(line);
                 }
@@ -256,8 +253,8 @@ pub async fn run_tui(
 
             output = event_stream.next() => {
                 let event = output
-                    .ok_or_else(|| miette!("No more crossterm events"))?
-                    .into_diagnostic()
+                    .ok_or_else(|| eyre!("No more crossterm events"))?
+
                     .wrap_err("Failed to get next crossterm event")?;
                 // TODO: `get_frame` is an expensive call, delay if possible.
                 // https://github.com/MercuryTechnologies/ghciwatch/pull/206#discussion_r1508364135

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -1,9 +1,8 @@
 use crossterm::cursor;
 use crossterm::event;
 use crossterm::terminal;
-use miette::miette;
-use miette::IntoDiagnostic;
-use miette::WrapErr;
+use eyre::eyre;
+use eyre::WrapErr;
 use ratatui::prelude::CrosstermBackend;
 use ratatui::prelude::Terminal;
 use std::io::Stdout;
@@ -53,11 +52,11 @@ static INSIDE: AtomicBool = AtomicBool::new(false);
 
 /// Enter raw-mode for the terminal on stdout, set up a panic hook, etc.
 #[instrument(level = "debug")]
-pub fn enter() -> miette::Result<TerminalGuard> {
+pub fn enter() -> eyre::Result<TerminalGuard> {
     use event::KeyboardEnhancementFlags as KEF;
 
     if INSIDE.load(Ordering::SeqCst) {
-        return Err(miette!(
+        return Err(eyre!(
             "Cannot enter raw mode; the terminal is already set up"
         ));
     }
@@ -67,9 +66,7 @@ pub fn enter() -> miette::Result<TerminalGuard> {
 
     let mut stdout = std::io::stdout();
 
-    terminal::enable_raw_mode()
-        .into_diagnostic()
-        .wrap_err("Failed to enable raw mode")?;
+    terminal::enable_raw_mode().wrap_err("Failed to enable raw mode")?;
 
     crossterm::execute!(
         stdout,
@@ -84,7 +81,6 @@ pub fn enter() -> miette::Result<TerminalGuard> {
                 | KEF::REPORT_ALL_KEYS_AS_ESCAPE_CODES
         ),
     )
-    .into_diagnostic()
     .wrap_err("Failed to execute crossterm commands")?;
 
     let previous_hook = panic::take_hook();
@@ -97,16 +93,14 @@ pub fn enter() -> miette::Result<TerminalGuard> {
 
     let backend = CrosstermBackend::new(stdout);
 
-    let terminal = Terminal::new(backend)
-        .into_diagnostic()
-        .wrap_err("Failed to create ratatui terminal")?;
+    let terminal = Terminal::new(backend).wrap_err("Failed to create ratatui terminal")?;
 
     Ok(TerminalGuard { terminal })
 }
 
 /// Exits terminal raw-mode.
 #[instrument(level = "debug")]
-pub fn exit() -> miette::Result<()> {
+pub fn exit() -> eyre::Result<()> {
     if !INSIDE.load(Ordering::SeqCst) {
         return Ok(());
     }
@@ -122,12 +116,9 @@ pub fn exit() -> miette::Result<()> {
         cursor::Show,
         terminal::LeaveAlternateScreen,
     )
-    .into_diagnostic()
     .wrap_err("Failed to execute crossterm commands")?;
 
-    terminal::disable_raw_mode()
-        .into_diagnostic()
-        .wrap_err("Failed to disable raw mode")?;
+    terminal::disable_raw_mode().wrap_err("Failed to disable raw mode")?;
 
     INSIDE.store(false, Ordering::SeqCst);
 

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
-use miette::miette;
-use miette::IntoDiagnostic;
+use eyre::eyre;
 use notify_debouncer_full::notify;
 use notify_debouncer_full::notify::PollWatcher;
 use notify_debouncer_full::notify::RecommendedWatcher;
@@ -53,7 +52,7 @@ pub async fn run_watcher(
     handle: ShutdownHandle,
     ghci_sender: mpsc::Sender<WatcherEvent>,
     opts: WatcherOpts,
-) -> miette::Result<()> {
+) -> eyre::Result<()> {
     if opts.poll.is_some() {
         run_debouncer::<PollWatcher>(handle, ghci_sender, opts).await
     } else {
@@ -65,7 +64,7 @@ async fn run_debouncer<T: notify::Watcher>(
     mut handle: ShutdownHandle,
     ghci_sender: mpsc::Sender<WatcherEvent>,
     opts: WatcherOpts,
-) -> miette::Result<()> {
+) -> eyre::Result<()> {
     let mut config = notify::Config::default();
     if let Some(interval) = opts.poll {
         config = config.with_poll_interval(interval);
@@ -88,8 +87,7 @@ async fn run_debouncer<T: notify::Watcher>(
         event_handler,
         cache,
         config,
-    )
-    .into_diagnostic()?;
+    )?;
 
     {
         let watcher = debouncer.watcher();
@@ -101,12 +99,12 @@ async fn run_debouncer<T: notify::Watcher>(
                         kind: notify::ErrorKind::Io(e),
                         ..
                     } if e.kind() == std::io::ErrorKind::NotFound => {
-                        miette!(
+                        eyre!(
                             "Cannot watch path that doesn't exist: {:?}",
                             path.absolute()
                         )
                     }
-                    err => miette!("{err}"),
+                    err => eyre!("{err}"),
                 })?;
         }
         let mut cache = debouncer.cache();
@@ -139,7 +137,7 @@ impl EventHandler {
         }
     }
 
-    async fn handle_event_inner(&self, event: DebounceEventResult) -> miette::Result<()> {
+    async fn handle_event_inner(&self, event: DebounceEventResult) -> eyre::Result<()> {
         let events = match event {
             Ok(events) => events,
             Err(errors) => {
@@ -154,7 +152,7 @@ impl EventHandler {
                 }
 
                 return if fatal_error {
-                    Err(miette!("Watching files failed"))
+                    Err(eyre!("Watching files failed"))
                 } else {
                     Ok(())
                 };
@@ -173,8 +171,7 @@ impl EventHandler {
             tracing::debug!(?events, "Processed events");
             self.ghci_sender
                 .send(WatcherEvent::Reload { events })
-                .await
-                .into_diagnostic()?;
+                .await?;
         }
 
         Ok(())

--- a/test-harness/Cargo.toml
+++ b/test-harness/Cargo.toml
@@ -11,8 +11,11 @@ clonable-command = "0.1.0"
 fs_extra = "1.3.0"
 futures-util = "0.3.28"
 itertools = "0.11.0"
-miette = { version = "5.9.0", features = ["fancy"] }
-nix = { version = "0.26.2", default-features = false, features = ["process", "signal"] }
+eyre = "*"
+nix = { version = "0.26.2", default-features = false, features = [
+  "process",
+  "signal",
+] }
 regex = "1.9.4"
 serde = { version = "1.0.186", features = ["derive"] }
 serde_json = "1.0.105"

--- a/test-harness/src/fs.rs
+++ b/test-harness/src/fs.rs
@@ -6,9 +6,8 @@ use std::time::Duration;
 
 use backoff::backoff::Backoff;
 use backoff::ExponentialBackoff;
-use miette::miette;
-use miette::Context;
-use miette::IntoDiagnostic;
+use eyre::eyre;
+use eyre::Context;
 use tokio::fs::File;
 use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
@@ -64,7 +63,7 @@ impl Fs {
 
     /// Touch a path.
     #[tracing::instrument]
-    pub async fn touch(&self, path: impl AsRef<Path> + Debug) -> miette::Result<()> {
+    pub async fn touch(&self, path: impl AsRef<Path> + Debug) -> eyre::Result<()> {
         let path = path.as_ref();
         if path.exists() {
             // I've had trouble with the pure-`open` approach getting detected, so let's actually
@@ -81,7 +80,6 @@ impl Fs {
                 .write(true)
                 .open(path)
                 .await
-                .into_diagnostic()
                 .wrap_err_with(|| format!("Failed to touch {path:?}"))
                 .map(|_| ())
         }
@@ -93,7 +91,7 @@ impl Fs {
         &self,
         path: impl AsRef<Path> + Debug,
         data: impl AsRef<[u8]>,
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         let path = path.as_ref();
         if let Some(parent) = path.parent() {
             self.create_dir(parent).await?;
@@ -103,7 +101,6 @@ impl Fs {
 
         tokio::fs::write(path, data)
             .await
-            .into_diagnostic()
             .wrap_err_with(|| format!("Failed to write {path:?}"))
     }
 
@@ -113,15 +110,15 @@ impl Fs {
         &self,
         path: impl AsRef<Path> + Debug,
         data: impl AsRef<[u8]>,
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         let path = path.as_ref();
         let mut file = OpenOptions::new()
             .append(true)
             .open(path)
             .await
-            .into_diagnostic()
             .wrap_err_with(|| format!("Failed to open {path:?}"))?;
-        file.write_all(data.as_ref()).await.into_diagnostic()
+        file.write_all(data.as_ref()).await?;
+        Ok(())
     }
 
     /// Prepend some data to a path.
@@ -130,30 +127,26 @@ impl Fs {
         &self,
         path: impl AsRef<Path> + Debug,
         data: impl AsRef<[u8]>,
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         let path = path.as_ref();
         let contents = self.read(path).await?;
         let mut file = File::create(path)
             .await
-            .into_diagnostic()
             .wrap_err_with(|| format!("Failed to open {path:?}"))?;
         file.write_all(data.as_ref())
             .await
-            .into_diagnostic()
             .wrap_err_with(|| format!("Failed to write {path:?}"))?;
         file.write_all(contents.as_ref())
             .await
-            .into_diagnostic()
             .wrap_err_with(|| format!("Failed to write {path:?}"))
     }
 
     /// Read a path into a string.
     #[tracing::instrument]
-    pub async fn read(&self, path: impl AsRef<Path> + Debug) -> miette::Result<String> {
+    pub async fn read(&self, path: impl AsRef<Path> + Debug) -> eyre::Result<String> {
         let path = path.as_ref();
         tokio::fs::read_to_string(path)
             .await
-            .into_diagnostic()
             .wrap_err_with(|| format!("Failed to read {path:?}"))
     }
 
@@ -164,25 +157,22 @@ impl Fs {
         path: impl AsRef<Path> + Debug,
         from: impl AsRef<str>,
         to: impl AsRef<str>,
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         let path = path.as_ref();
         let old_contents = self.read(path).await?;
         let new_contents = old_contents.replace(from.as_ref(), to.as_ref());
         if old_contents == new_contents {
-            return Err(miette!(
-                "Replacing substring in file didn't make any changes"
-            ));
+            return Err(eyre!("Replacing substring in file didn't make any changes"));
         }
         self.write(path, new_contents).await
     }
 
     /// Creates a directory and all of its parent components.
     #[tracing::instrument]
-    pub async fn create_dir(&self, path: impl AsRef<Path> + Debug) -> miette::Result<()> {
+    pub async fn create_dir(&self, path: impl AsRef<Path> + Debug) -> eyre::Result<()> {
         let path = path.as_ref();
         tokio::fs::create_dir_all(path)
             .await
-            .into_diagnostic()
             .wrap_err_with(|| format!("Failed to create directory {path:?}"))
     }
 
@@ -190,14 +180,13 @@ impl Fs {
     ///
     /// Directories are removed recursively; be careful.
     #[tracing::instrument]
-    pub async fn remove(&self, path: impl AsRef<Path> + Debug) -> miette::Result<()> {
+    pub async fn remove(&self, path: impl AsRef<Path> + Debug) -> eyre::Result<()> {
         let path = path.as_ref();
         if path.is_dir() {
             tokio::fs::remove_dir_all(path).await
         } else {
             tokio::fs::remove_file(path).await
         }
-        .into_diagnostic()
         .wrap_err_with(|| format!("Failed to remove {path:?}"))
     }
 
@@ -207,12 +196,11 @@ impl Fs {
         &self,
         from: impl AsRef<Path> + Debug,
         to: impl AsRef<Path> + Debug,
-    ) -> miette::Result<()> {
+    ) -> eyre::Result<()> {
         let from = from.as_ref();
         let to = to.as_ref();
         tokio::fs::rename(from, to)
             .await
-            .into_diagnostic()
             .wrap_err_with(|| format!("Failed to move {from:?} to {to:?}"))
     }
 
@@ -220,7 +208,7 @@ impl Fs {
     ///
     /// This should generally be run under a [`tokio::time::timeout`].
     #[tracing::instrument]
-    pub async fn wait_for_path(&self, duration: Duration, path: &Path) -> miette::Result<()> {
+    pub async fn wait_for_path(&self, duration: Duration, path: &Path) -> eyre::Result<()> {
         let mut backoff = ExponentialBackoff {
             max_interval: Duration::from_secs(1),
             max_elapsed_time: Some(duration),
@@ -233,7 +221,7 @@ impl Fs {
             tracing::debug!("Waiting {duration:?} before retrying");
             tokio::time::sleep(duration).await;
         }
-        Err(miette!(
+        Err(eyre!(
             "Path was not created after waiting {duration:.2?}: {path:?}"
         ))
     }

--- a/test-harness/src/ghc_version.rs
+++ b/test-harness/src/ghc_version.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 use std::str::FromStr;
 use std::sync::OnceLock;
 
-use miette::miette;
+use eyre::eyre;
 use regex::Regex;
 
 /// A GHC version, including the patch level.
@@ -15,7 +15,7 @@ pub struct FullGhcVersion {
 
 impl FullGhcVersion {
     /// Get the GHC version for the current test.
-    pub fn current() -> miette::Result<Self> {
+    pub fn current() -> eyre::Result<Self> {
         let full = crate::internal::get_ghc_version()?;
         let major = full.parse()?;
         Ok(Self { full, major })
@@ -51,11 +51,11 @@ fn ghc_version_re() -> &'static Regex {
 }
 
 impl FromStr for GhcVersion {
-    type Err = miette::Error;
+    type Err = eyre::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let captures = ghc_version_re().captures(s).ok_or_else(|| {
-            miette!("Failed to parse GHC version. Expected a string like \"9.6.2\", got {s:?}")
+            eyre!("Failed to parse GHC version. Expected a string like \"9.6.2\", got {s:?}")
         })?;
 
         let (_full, [major, minor, _patch]) = captures.extract();
@@ -66,7 +66,7 @@ impl FromStr for GhcVersion {
             ("9", "8") => Ok(Self::Ghc98),
             ("9", "10") => Ok(Self::Ghc910),
             ("9", "12") => Ok(Self::Ghc912),
-            (_, _) => Err(miette!(
+            (_, _) => Err(eyre!(
                 "Only the following GHC versions are supported:\n\
                 - 9.4\n\
                 - 9.6\n\

--- a/test-harness/src/ghciwatch.rs
+++ b/test-harness/src/ghciwatch.rs
@@ -8,11 +8,10 @@ use std::process::ExitStatus;
 use std::time::Duration;
 
 use clonable_command::Command as ClonableCommand;
+use eyre::eyre;
+use eyre::Context;
 use futures_util::future::BoxFuture;
 use itertools::Itertools;
-use miette::miette;
-use miette::Context;
-use miette::IntoDiagnostic;
 use tap::Conv;
 use tokio::process::Command;
 
@@ -38,7 +37,7 @@ pub struct GhciWatchBuilder {
     cabal_args: Vec<String>,
     cabal_target: String,
     #[allow(clippy::type_complexity)]
-    before_start: Option<Box<dyn FnOnce(PathBuf) -> BoxFuture<'static, miette::Result<()>> + Send>>,
+    before_start: Option<Box<dyn FnOnce(PathBuf) -> BoxFuture<'static, eyre::Result<()>> + Send>>,
     default_timeout: Duration,
     startup_timeout: Duration,
     log_filters: Vec<String>,
@@ -112,7 +111,7 @@ impl GhciWatchBuilder {
     /// `ghciwatch` is started.
     pub fn before_start<F>(mut self, before_start: impl Fn(PathBuf) -> F + Send + 'static) -> Self
     where
-        F: Future<Output = miette::Result<()>> + Send + 'static,
+        F: Future<Output = eyre::Result<()>> + Send + 'static,
     {
         self.before_start = Some(Box::new(move |path| Box::pin(before_start(path))));
         self
@@ -137,7 +136,7 @@ impl GhciWatchBuilder {
     }
 
     /// Start `ghciwatch`.
-    pub async fn start(self) -> miette::Result<GhciWatch> {
+    pub async fn start(self) -> eyre::Result<GhciWatch> {
         GhciWatch::from_builder(self).await
     }
 
@@ -226,7 +225,7 @@ impl Session {
         command: &ClonableCommand,
         timeout: Duration,
         log_path: &Path,
-    ) -> miette::Result<Self> {
+    ) -> eyre::Result<Self> {
         let fs = Fs::new();
         if log_path.exists() {
             fs.remove(log_path).await?;
@@ -238,7 +237,6 @@ impl Session {
             .conv::<Command>()
             .kill_on_drop(true)
             .spawn()
-            .into_diagnostic()
             .wrap_err("Failed to start `ghciwatch`")?;
 
         let creates_log_path = fs.wait_for_path(timeout, log_path);
@@ -246,10 +244,10 @@ impl Session {
             child_result = child.wait() => {
                 return match child_result {
                     Err(err) => {
-                        Err(err).into_diagnostic().wrap_err("ghciwatch failed to execute")
+                        Err(err).wrap_err("ghciwatch failed to execute")
                     }
                     Ok(status) => {
-                        Err(miette!("ghciwatch exited: {status}"))
+                        Err(eyre!("ghciwatch exited: {status}"))
                     }
                 }
             }
@@ -259,9 +257,7 @@ impl Session {
             else => {}
         }
 
-        let pid = child
-            .id()
-            .ok_or_else(|| miette!("`ghciwatch` has no PID"))?;
+        let pid = child.id().ok_or_else(|| eyre!("`ghciwatch` has no PID"))?;
 
         crate::internal::set_ghciwatch_process(child)?;
 
@@ -301,7 +297,7 @@ pub struct GhciWatch {
 }
 
 impl GhciWatch {
-    async fn from_builder(mut builder: GhciWatchBuilder) -> miette::Result<Self> {
+    async fn from_builder(mut builder: GhciWatchBuilder) -> eyre::Result<Self> {
         let ghc_version = FullGhcVersion::current()?;
         let tempdir = crate::internal::set_tempdir()?;
         let fs = Fs::new();
@@ -314,11 +310,10 @@ impl GhciWatch {
         let paths_to_copy = vec![&builder.project_directory];
         tracing::info!(?paths_to_copy, "Copying project files");
         fs_extra::copy_items(&paths_to_copy, &tempdir, &Default::default())
-            .into_diagnostic()
             .wrap_err("Failed to copy project files")?;
 
         let project_directory_name = builder.project_directory.file_name().ok_or_else(|| {
-            miette!(
+            eyre!(
                 "Path has no directory name: {:?}",
                 builder.project_directory
             )
@@ -395,7 +390,7 @@ impl GhciWatch {
     }
 
     /// Start a new `ghciwatch` session in a copy of the given path.
-    pub async fn new(project_directory: impl AsRef<Path>) -> miette::Result<Self> {
+    pub async fn new(project_directory: impl AsRef<Path>) -> eyre::Result<Self> {
         GhciWatchBuilder::new(project_directory).start().await
     }
 
@@ -408,7 +403,7 @@ impl GhciWatch {
     }
 
     /// Read an event from the `ghciwatch` session.
-    async fn read_event(&mut self) -> miette::Result<&Event> {
+    async fn read_event(&mut self) -> eyre::Result<&Event> {
         let event = self.ghciwatch.tracing_reader.next_event().await?;
         self.events.push(event);
         Ok(self.events.last().expect("We just inserted this event"))
@@ -417,7 +412,7 @@ impl GhciWatch {
     /// Find a matching event in previously-read events.
     ///
     /// Returns the first matching event, or `None` if no matching events were found.
-    fn find_logged(&self, matcher: &mut dyn Matcher) -> miette::Result<Option<&Event>> {
+    fn find_logged(&self, matcher: &mut dyn Matcher) -> eyre::Result<Option<&Event>> {
         for event in &self.events {
             if matcher.matches(event)? {
                 return Ok(Some(event));
@@ -427,10 +422,10 @@ impl GhciWatch {
     }
 
     /// Assert that a matching event was logged.
-    pub fn assert_logged(&self, matcher: impl IntoMatcher) -> miette::Result<&Event> {
+    pub fn assert_logged(&self, matcher: impl IntoMatcher) -> eyre::Result<&Event> {
         let mut matcher = matcher.into_matcher()?;
         self.find_logged(&mut matcher)?
-            .ok_or_else(|| miette!("No log message matching {matcher} found"))
+            .ok_or_else(|| eyre!("No log message matching {matcher} found"))
     }
 
     /// Wait until a matching log event is found, with the given timeout.
@@ -444,7 +439,7 @@ impl GhciWatch {
         matcher: impl IntoMatcher,
         check_existing: bool,
         timeout_duration: Duration,
-    ) -> miette::Result<Event> {
+    ) -> eyre::Result<Event> {
         let timeout_duration = timeout_mult(timeout_duration)?;
 
         let mut matcher = matcher.into_matcher()?;
@@ -467,7 +462,7 @@ impl GhciWatch {
         {
             Ok(Ok(event)) => Ok(event),
             Ok(Err(err)) => Err(err),
-            Err(_) => Err(miette!(
+            Err(_) => Err(eyre!(
                 "Waiting for a log message matching {matcher} \
                  timed out after {timeout_duration:.2?}"
             )),
@@ -481,7 +476,7 @@ impl GhciWatch {
         &mut self,
         matcher: impl IntoMatcher,
         timeout_duration: Duration,
-    ) -> miette::Result<Event> {
+    ) -> eyre::Result<Event> {
         self.wait_for_log_with_timeout_inner(matcher, false, timeout_duration)
             .await
     }
@@ -491,23 +486,20 @@ impl GhciWatch {
     pub async fn assert_logged_or_wait(
         &mut self,
         matcher: impl IntoMatcher,
-    ) -> miette::Result<Event> {
+    ) -> eyre::Result<Event> {
         self.wait_for_log_with_timeout_inner(matcher, true, self.default_timeout)
             .await
     }
 
     /// Wait until a matching log event is found with the `default_timeout`.
-    pub async fn wait_for_log(&mut self, matcher: impl IntoMatcher) -> miette::Result<Event> {
+    pub async fn wait_for_log(&mut self, matcher: impl IntoMatcher) -> eyre::Result<Event> {
         self.wait_for_log_with_timeout_inner(matcher, false, self.default_timeout)
             .await
     }
 
     /// Wait for a matching log event with the `startup_timeout`, checking previously-read
     /// events first.
-    pub async fn wait_for_startup_log(
-        &mut self,
-        matcher: impl IntoMatcher,
-    ) -> miette::Result<Event> {
+    pub async fn wait_for_startup_log(&mut self, matcher: impl IntoMatcher) -> eyre::Result<Event> {
         self.wait_for_log_with_timeout_inner(matcher, true, self.startup_timeout)
             .await
     }
@@ -515,7 +507,7 @@ impl GhciWatch {
     /// Wait until `ghciwatch` completes its initial load.
     ///
     /// Returns immediately if `ghciwatch` has already completed its initial load.
-    pub async fn wait_until_started(&mut self) -> miette::Result<()> {
+    pub async fn wait_until_started(&mut self) -> eyre::Result<()> {
         self.wait_for_log_with_timeout_inner(
             BaseMatcher::ghci_started(),
             true,
@@ -529,7 +521,7 @@ impl GhciWatch {
     /// Wait until `ghciwatch` is ready to receive file events.
     ///
     /// Returns immediately if `ghciwatch` has already become ready to receive file events.
-    pub async fn wait_until_watcher_started(&mut self) -> miette::Result<()> {
+    pub async fn wait_until_watcher_started(&mut self) -> eyre::Result<()> {
         self.wait_for_log_with_timeout_inner(
             BaseMatcher::watcher_started(),
             true,
@@ -544,7 +536,7 @@ impl GhciWatch {
     ///
     /// Returns immediately if `ghciwatch` has already completed its initial load and become ready
     /// to receive file events.
-    pub async fn wait_until_ready(&mut self) -> miette::Result<()> {
+    pub async fn wait_until_ready(&mut self) -> eyre::Result<()> {
         self.wait_for_log_with_timeout_inner(
             BaseMatcher::ghci_started().and(BaseMatcher::watcher_started()),
             true,
@@ -556,34 +548,33 @@ impl GhciWatch {
     }
 
     /// Wait until `ghciwatch` reloads the `ghci` session due to changed modules.
-    pub async fn wait_until_reload(&mut self) -> miette::Result<()> {
+    pub async fn wait_until_reload(&mut self) -> eyre::Result<()> {
         // TODO: It would be nice to verify which modules are changed.
         self.wait_for_log(BaseMatcher::ghci_reload()).await?;
         Ok(())
     }
 
     /// Wait until `ghciwatch` adds new modules to the `ghci` session.
-    pub async fn wait_until_add(&mut self) -> miette::Result<()> {
+    pub async fn wait_until_add(&mut self) -> eyre::Result<()> {
         // TODO: It would be nice to verify which modules are being added.
         self.wait_for_log(BaseMatcher::ghci_add()).await?;
         Ok(())
     }
 
     /// Wait until `ghciwatch` restarts the `ghci` session.
-    pub async fn wait_until_restart(&mut self) -> miette::Result<()> {
+    pub async fn wait_until_restart(&mut self) -> eyre::Result<()> {
         // TODO: It would be nice to verify which modules have been deleted/moved.
         self.wait_for_log(BaseMatcher::ghci_restart()).await?;
         Ok(())
     }
 
     /// Wait until `ghciwatch` exits and return its status.
-    pub async fn wait_until_exit(&self) -> miette::Result<ExitStatus> {
+    pub async fn wait_until_exit(&self) -> eyre::Result<ExitStatus> {
         let mut child = crate::internal::take_ghciwatch_process()?;
 
         let status = child
             .wait()
             .await
-            .into_diagnostic()
             .wrap_err("Failed to wait for `ghciwatch` to exit")?;
 
         // Put it back.
@@ -593,7 +584,7 @@ impl GhciWatch {
     }
 
     /// Restart the `ghciwatch` session.
-    pub async fn restart_ghciwatch(&mut self) -> miette::Result<()> {
+    pub async fn restart_ghciwatch(&mut self) -> eyre::Result<()> {
         let child = crate::internal::take_ghciwatch_process()?;
         crate::internal::send_signal(&child, nix::sys::signal::Signal::SIGINT)?;
         // Put it back.
@@ -639,10 +630,8 @@ impl GhciWatch {
 /// Write an empty `~/.cabal/config` so that `cabal` doesn't try to access the internet.
 ///
 /// See: <https://github.com/haskell/cabal/issues/6167>
-async fn write_cabal_config(fs: &Fs, home: &Path) -> miette::Result<()> {
-    std::fs::create_dir_all(home.join(".cabal"))
-        .into_diagnostic()
-        .wrap_err("Failed to create `.cabal` directory")?;
+async fn write_cabal_config(fs: &Fs, home: &Path) -> eyre::Result<()> {
+    std::fs::create_dir_all(home.join(".cabal")).wrap_err("Failed to create `.cabal` directory")?;
     fs.touch(home.join(".cabal/config"))
         .await
         .wrap_err("Failed to write empty `.cabal/config`")?;
@@ -653,12 +642,11 @@ async fn write_cabal_config(fs: &Fs, home: &Path) -> miette::Result<()> {
 ///
 /// This is a nice check that the given GHC version is present in the environment, to fail tests
 /// early without waiting for `ghciwatch` to fail.
-async fn check_ghc_version(home: &Path, ghc_version: &FullGhcVersion) -> miette::Result<()> {
+async fn check_ghc_version(home: &Path, ghc_version: &FullGhcVersion) -> eyre::Result<()> {
     let _output = Command::new(format!("ghc-{ghc_version}"))
         .env("HOME", home)
         .output()
         .await
-        .into_diagnostic()
         .wrap_err_with(|| format!("Failed to find GHC {ghc_version}"))?;
     // `ghc --version` returns a nonzero status code. As long as we could actually execute it, it's
     // OK if it failed.

--- a/test-harness/src/internal.rs
+++ b/test-harness/src/internal.rs
@@ -5,9 +5,8 @@ use std::future::Future;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use miette::miette;
-use miette::Context;
-use miette::IntoDiagnostic;
+use eyre::eyre;
+use eyre::Context;
 use nix::sys::signal;
 use nix::sys::signal::Signal;
 use nix::unistd::Pid;
@@ -156,10 +155,10 @@ async fn cleanup() {
 }
 
 /// Get the GHC version for this thread as given by `GHC_VERSION`.
-pub(crate) fn get_ghc_version() -> miette::Result<String> {
+pub(crate) fn get_ghc_version() -> eyre::Result<String> {
     let ghc_version = GHC_VERSION.with(|version| version.borrow().to_owned());
     if ghc_version.is_empty() {
-        Err(miette!("`GHC_VERSION` is not set"))
+        Err(eyre!("`GHC_VERSION` is not set"))
             .wrap_err("`GhciWatch` can only be used in `#[test_harness::test]` functions")
     } else {
         Ok(ghc_version)
@@ -169,15 +168,13 @@ pub(crate) fn get_ghc_version() -> miette::Result<String> {
 /// Create a new temporary directory and set [`TEMPDIR`] to it, persisting it to disk.
 ///
 /// Fails if [`TEMPDIR`] is already set.
-pub(crate) fn set_tempdir() -> miette::Result<PathBuf> {
-    let tempdir = tempfile::tempdir()
-        .into_diagnostic()
-        .wrap_err("Failed to create temporary directory")?;
+pub(crate) fn set_tempdir() -> eyre::Result<PathBuf> {
+    let tempdir = tempfile::tempdir().wrap_err("Failed to create temporary directory")?;
 
     // Set the thread-local tempdir for cleanup later.
     TEMPDIR.with(|thread_tempdir| {
         if thread_tempdir.borrow().is_some() {
-            return Err(miette!(
+            return Err(eyre!(
                 "`GhciWatch` can only be constructed once per `#[test_harness::test]` function"
             ));
         }
@@ -192,10 +189,10 @@ pub(crate) fn set_tempdir() -> miette::Result<PathBuf> {
 /// Set the `GHCIWATCH_PROCESS` for the current thread to the given [`Child`].
 ///
 /// Fails if the `GHCIWATCH_PROCESS` is already set.
-pub(crate) fn set_ghciwatch_process(child: Child) -> miette::Result<()> {
+pub(crate) fn set_ghciwatch_process(child: Child) -> eyre::Result<()> {
     GHCIWATCH_PROCESS.with(|maybe_child| {
         if maybe_child.borrow().is_some() {
-            return Err(miette!(
+            return Err(eyre!(
                 "`GhciWatch` can only be constructed once per `#[test_harness::test]` function"
             ));
         }
@@ -209,24 +206,23 @@ pub(crate) fn set_ghciwatch_process(child: Child) -> miette::Result<()> {
 /// Take the `GHCIWATCH_PROCESS` for the current thread.
 ///
 /// Fails if the `GHCIWATCH_PROCESS` is not set.
-pub(crate) fn take_ghciwatch_process() -> miette::Result<Child> {
+pub(crate) fn take_ghciwatch_process() -> eyre::Result<Child> {
     GHCIWATCH_PROCESS
         .with(|child| child.take())
-        .ok_or_else(|| miette!("GHCIWATCH_PROCESS is not set; have you constructed a `GhciWatch`?"))
+        .ok_or_else(|| eyre!("GHCIWATCH_PROCESS is not set; have you constructed a `GhciWatch`?"))
 }
 
 /// Send a signal to a child process.
-pub(crate) fn send_signal(child: &Child, signal: Signal) -> miette::Result<()> {
+pub(crate) fn send_signal(child: &Child, signal: Signal) -> eyre::Result<()> {
     signal::kill(
         Pid::from_raw(
             child
                 .id()
-                .ok_or_else(|| miette!("Command has no pid, likely because it has already exited"))?
+                .ok_or_else(|| eyre!("Command has no pid, likely because it has already exited"))?
                 .try_into()
-                .into_diagnostic()
                 .wrap_err("Failed to convert pid type")?,
         ),
         signal,
-    )
-    .into_diagnostic()
+    )?;
+    Ok(())
 }

--- a/test-harness/src/matcher/and_matcher.rs
+++ b/test-harness/src/matcher/and_matcher.rs
@@ -22,7 +22,7 @@ where
     A: Display + Matcher,
     B: Display + Matcher,
 {
-    fn matches(&mut self, event: &Event) -> miette::Result<bool> {
+    fn matches(&mut self, event: &Event) -> eyre::Result<bool> {
         // There may be some overlap in the events these matchers require to complete, so
         // we eagerly evaluate both matchers before combining the boolean result.
         let match_a = self.0.matches(event)?;

--- a/test-harness/src/matcher/base_matcher.rs
+++ b/test-harness/src/matcher/base_matcher.rs
@@ -202,7 +202,7 @@ impl Display for BaseMatcher {
 }
 
 impl Matcher for BaseMatcher {
-    fn matches(&mut self, event: &Event) -> miette::Result<bool> {
+    fn matches(&mut self, event: &Event) -> eyre::Result<bool> {
         if !self.message.is_match(&event.message) {
             return Ok(false);
         }

--- a/test-harness/src/matcher/fused_matcher.rs
+++ b/test-harness/src/matcher/fused_matcher.rs
@@ -26,7 +26,7 @@ impl<M: Display> Display for FusedMatcher<M> {
 }
 
 impl<M: Matcher> Matcher for FusedMatcher<M> {
-    fn matches(&mut self, event: &crate::Event) -> miette::Result<bool> {
+    fn matches(&mut self, event: &crate::Event) -> eyre::Result<bool> {
         if self.matched {
             Ok(true)
         } else {

--- a/test-harness/src/matcher/into_matcher.rs
+++ b/test-harness/src/matcher/into_matcher.rs
@@ -1,4 +1,4 @@
-use miette::Diagnostic;
+use std::error::Error as StdError;
 
 use crate::BaseMatcher;
 use crate::Matcher;
@@ -9,7 +9,7 @@ pub trait IntoMatcher {
     type Matcher: Matcher;
 
     /// Convert the object into a `Matcher`.
-    fn into_matcher(self) -> miette::Result<Self::Matcher>;
+    fn into_matcher(self) -> eyre::Result<Self::Matcher>;
 }
 
 impl<M> IntoMatcher for M
@@ -18,7 +18,7 @@ where
 {
     type Matcher = Self;
 
-    fn into_matcher(self) -> miette::Result<Self::Matcher> {
+    fn into_matcher(self) -> eyre::Result<Self::Matcher> {
         Ok(self)
     }
 }
@@ -26,7 +26,7 @@ where
 impl IntoMatcher for &BaseMatcher {
     type Matcher = BaseMatcher;
 
-    fn into_matcher(self) -> miette::Result<Self::Matcher> {
+    fn into_matcher(self) -> eyre::Result<Self::Matcher> {
         Ok(self.clone())
     }
 }
@@ -34,7 +34,7 @@ impl IntoMatcher for &BaseMatcher {
 impl IntoMatcher for &str {
     type Matcher = BaseMatcher;
 
-    fn into_matcher(self) -> miette::Result<Self::Matcher> {
+    fn into_matcher(self) -> eyre::Result<Self::Matcher> {
         Ok(BaseMatcher::message(self))
     }
 }
@@ -42,11 +42,11 @@ impl IntoMatcher for &str {
 impl<M, E> IntoMatcher for Result<M, E>
 where
     M: IntoMatcher,
-    E: Diagnostic + Send + Sync + 'static,
+    E: StdError + Send + Sync + 'static,
 {
     type Matcher = <M as IntoMatcher>::Matcher;
 
-    fn into_matcher(self) -> miette::Result<Self::Matcher> {
-        self.map_err(|err| miette::Report::new(err))?.into_matcher()
+    fn into_matcher(self) -> eyre::Result<Self::Matcher> {
+        self.map_err(eyre::Report::new)?.into_matcher()
     }
 }

--- a/test-harness/src/matcher/mod.rs
+++ b/test-harness/src/matcher/mod.rs
@@ -37,7 +37,7 @@ pub trait Matcher: Display {
     /// Feeds an event to the matcher and determines if the matcher has finished.
     ///
     /// Note that matchers may need multiple separate log messages to complete matching.
-    fn matches(&mut self, event: &Event) -> miette::Result<bool>;
+    fn matches(&mut self, event: &Event) -> eyre::Result<bool>;
 
     /// Construct a matcher that matches when this matcher or the `other` matcher have
     /// finished matching.
@@ -83,7 +83,7 @@ impl<M> Matcher for &mut M
 where
     M: Matcher,
 {
-    fn matches(&mut self, event: &Event) -> miette::Result<bool> {
+    fn matches(&mut self, event: &Event) -> eyre::Result<bool> {
         (*self).matches(event)
     }
 }

--- a/test-harness/src/matcher/negative_matcher.rs
+++ b/test-harness/src/matcher/negative_matcher.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use miette::miette;
+use eyre::eyre;
 
 use crate::Event;
 use crate::Matcher;
@@ -35,9 +35,9 @@ where
     A: Display + Matcher,
     B: Display + Matcher,
 {
-    fn matches(&mut self, event: &Event) -> miette::Result<bool> {
+    fn matches(&mut self, event: &Event) -> eyre::Result<bool> {
         if self.negative.matches(event)? {
-            Err(miette!("Log event matched {}: {}", self.negative, event))
+            Err(eyre!("Log event matched {}: {}", self.negative, event))
         } else if self.inner.matches(event)? {
             Ok(true)
         } else {

--- a/test-harness/src/matcher/never_matcher.rs
+++ b/test-harness/src/matcher/never_matcher.rs
@@ -13,7 +13,7 @@ impl Display for NeverMatcher {
 }
 
 impl Matcher for NeverMatcher {
-    fn matches(&mut self, _event: &crate::Event) -> miette::Result<bool> {
+    fn matches(&mut self, _event: &crate::Event) -> eyre::Result<bool> {
         Ok(false)
     }
 }

--- a/test-harness/src/matcher/option_matcher.rs
+++ b/test-harness/src/matcher/option_matcher.rs
@@ -35,7 +35,7 @@ impl<M: Display> Display for OptionMatcher<M> {
 }
 
 impl<M: Matcher> Matcher for OptionMatcher<M> {
-    fn matches(&mut self, event: &crate::Event) -> miette::Result<bool> {
+    fn matches(&mut self, event: &crate::Event) -> eyre::Result<bool> {
         match &mut self.0 {
             Some(ref mut matcher) => matcher.matches(event),
             None => Ok(false),
@@ -46,7 +46,7 @@ impl<M: Matcher> Matcher for OptionMatcher<M> {
 impl<M: Matcher> IntoMatcher for Option<M> {
     type Matcher = OptionMatcher<M>;
 
-    fn into_matcher(self) -> miette::Result<Self::Matcher> {
+    fn into_matcher(self) -> eyre::Result<Self::Matcher> {
         Ok(OptionMatcher(self))
     }
 }

--- a/test-harness/src/matcher/or_matcher.rs
+++ b/test-harness/src/matcher/or_matcher.rs
@@ -22,7 +22,7 @@ where
     A: Display + Matcher,
     B: Display + Matcher,
 {
-    fn matches(&mut self, event: &Event) -> miette::Result<bool> {
+    fn matches(&mut self, event: &Event) -> eyre::Result<bool> {
         // There may be some overlap in the events these matchers require to complete, so we
         // eagerly evaluate both matchers before combining the boolean result.
         let match_a = self.0.matches(event)?;

--- a/test-harness/src/timeout_mult.rs
+++ b/test-harness/src/timeout_mult.rs
@@ -1,23 +1,22 @@
 use std::sync::OnceLock;
 use std::time::Duration;
 
-use miette::miette;
-use miette::Context;
-use miette::IntoDiagnostic;
+use eyre::eyre;
+use eyre::Context;
 
 const TIMEOUT_MULT_VAR: &str = "TIMEOUT_MULT";
 const DEFAULT_TIMEOUT_MULT: f64 = 1.0;
 
-static TIMEOUT_MULT: OnceLock<miette::Result<f64>> = OnceLock::new();
+static TIMEOUT_MULT: OnceLock<eyre::Result<f64>> = OnceLock::new();
 
 /// Multiply a [`Duration`] by the `$TIMEOUT_MULT`.
 ///
 /// See: [`get_timeout_mult`].
-pub fn timeout_mult(duration: Duration) -> miette::Result<Duration> {
+pub fn timeout_mult(duration: Duration) -> eyre::Result<Duration> {
     match get_timeout_mult() {
         Ok(mult) => Ok(duration.mul_f64(*mult)),
         // lol
-        Err(err) => Err(miette!("{err}")),
+        Err(err) => Err(eyre!("{err}")),
     }
 }
 
@@ -25,19 +24,14 @@ pub fn timeout_mult(duration: Duration) -> miette::Result<Duration> {
 ///
 /// This is a multiplier for all test timeout durations; it's used to make tests more reliable in CI
 /// and under load.
-pub fn get_timeout_mult() -> &'static miette::Result<f64> {
+pub fn get_timeout_mult() -> &'static eyre::Result<f64> {
     TIMEOUT_MULT.get_or_init(get_timeout_mult_inner)
 }
 
-fn get_timeout_mult_inner() -> miette::Result<f64> {
+fn get_timeout_mult_inner() -> eyre::Result<f64> {
     match std::env::var(TIMEOUT_MULT_VAR) {
-        Ok(raw) => raw
-            .parse()
-            .into_diagnostic()
-            .wrap_err("Failed to parse `$TIMEOUT_MULT`"),
+        Ok(raw) => raw.parse().wrap_err("Failed to parse `$TIMEOUT_MULT`"),
         Err(std::env::VarError::NotPresent) => Ok(DEFAULT_TIMEOUT_MULT),
-        Err(err) => Err(err)
-            .into_diagnostic()
-            .wrap_err("Failed to get `$TIMEOUT_MULT`"),
+        Err(err) => Err(err).wrap_err("Failed to get `$TIMEOUT_MULT`"),
     }
 }

--- a/test-harness/src/tracing_json.rs
+++ b/test-harness/src/tracing_json.rs
@@ -1,8 +1,7 @@
 use std::collections::HashMap;
 use std::fmt::Display;
 
-use miette::Context;
-use miette::IntoDiagnostic;
+use eyre::Context;
 use serde::Deserialize;
 use tracing::Level;
 
@@ -69,7 +68,7 @@ impl Display for Event {
 }
 
 impl TryFrom<JsonEvent> for Event {
-    type Error = miette::Report;
+    type Error = eyre::Report;
 
     fn try_from(event: JsonEvent) -> Result<Self, Self::Error> {
         Ok(Self {
@@ -77,7 +76,6 @@ impl TryFrom<JsonEvent> for Event {
             level: event
                 .level
                 .parse()
-                .into_diagnostic()
                 .wrap_err_with(|| format!("Failed to parse tracing level: {}", event.level))?,
             message: event.fields.message,
             fields: event.fields.fields,

--- a/test-harness/src/tracing_reader.rs
+++ b/test-harness/src/tracing_reader.rs
@@ -3,8 +3,7 @@ use std::time::Duration;
 
 use backoff::backoff::Backoff;
 use backoff::ExponentialBackoff;
-use miette::Context;
-use miette::IntoDiagnostic;
+use eyre::Context;
 use tokio::fs::File;
 use tokio::io::AsyncBufReadExt;
 use tokio::io::BufReader;
@@ -23,12 +22,11 @@ impl TracingReader {
     /// This watches for data to be read from the given `path`. When a line is written to `path`
     /// (by `ghciwatch`), the `TracingReader` will deserialize the line from JSON into an [`Event`]
     /// and send it to the given `sender` for another task to receive.
-    pub async fn new(path: impl AsRef<Path>) -> miette::Result<Self> {
+    pub async fn new(path: impl AsRef<Path>) -> eyre::Result<Self> {
         let path = path.as_ref();
 
         let file = File::open(path)
             .await
-            .into_diagnostic()
             .wrap_err_with(|| format!("Failed to open {path:?}"))?;
 
         let lines = BufReader::new(file).lines();
@@ -39,7 +37,7 @@ impl TracingReader {
     /// Read the next event from the contained file.
     ///
     /// This will block indefinitely until a line is written to the contained file.
-    pub async fn next_event(&mut self) -> miette::Result<Event> {
+    pub async fn next_event(&mut self) -> eyre::Result<Event> {
         let mut backoff = ExponentialBackoff {
             max_elapsed_time: None,
             max_interval: Duration::from_secs(1),
@@ -47,9 +45,8 @@ impl TracingReader {
         };
 
         while let Some(duration) = backoff.next_backoff() {
-            if let Some(line) = self.lines.next_line().await.into_diagnostic()? {
+            if let Some(line) = self.lines.next_line().await? {
                 let event = serde_json::from_str(&line)
-                    .into_diagnostic()
                     .wrap_err_with(|| format!("Failed to deserialize JSON: {line}"))?;
                 return Ok(event);
             }


### PR DESCRIPTION
`miette::IntoDiagnostic` hides the original error from downcasting methods, which means that it's impossible (in the rare cases where we want one) to get an error _out_ of a `miette::Result` to match on it.

`IntoDiagnostic` is mandatory for error types that don't implement `miette::Diagnostic`, which (inherently) includes all of the `std` error types. I could define my own wrapper types for everything I want to match on, but that's a big hassle that just isn't worth it.

This has been an open issue for 4 years now, but we haven't really needed to match on inner errors before. Now that we do, it's a dealbreaker.

See: https://github.com/zkat/miette/issues/155
