### PR TITLE
DUX-5109 Avoid stderr `get_buffer` busy-loop

### DIFF
--- a/src/ghci/stderr.rs
+++ b/src/ghci/stderr.rs
@@ -123,6 +123,7 @@ impl GhciStderr {
                 }
                 None => {
                     tracing::debug!("No more lines available from stderr");
+                    break;
                 }
             }
         }


### PR DESCRIPTION
If `next_line()` returns `None` in under 50ms (which happens if the stream has been closed, e.g. because the `ghci` process died), we busy-loop forever! There should be a `break;` here.