### PR TITLE
DUX-5110 Don't cancel startup before writing an error log

### DIFF
--- a/src/ghci/manager.rs
+++ b/src/ghci/manager.rs
@@ -68,25 +68,36 @@ pub async fn run_ghci(
         .wrap_err("Failed to start `ghci`")?;
 
     // Wait for ghci to finish loading.
+    //
+    // NB: We wait for the `ghci.initialize()` call to complete _even if_ `ghci` exits mid-way
+    // through; this lets us read the rest of its output and write a compilation log for startup
+    // errors.
     let mut log = CompilationLog::default();
-    // Use biased select with exited_receiver before startup_result. When ghci dies, its stdout
-    // closes and read_until enters a yield loop (returning Ok(None) on each EOF read), so
-    // startup_result never completes. exited_receiver.recv() fires once GhciProcess detects the
-    // exit, and with biased polling it is guaranteed to win once a message is available.
-    let startup_exit: Option<ExitStatus> = tokio::select! {
-        biased;
+    tokio::select! {
         _ = handle.on_shutdown_requested() => {
             ghci.stop().await.wrap_err("Failed to quit ghci")?;
             return Ok(());
         }
-        Some(status) = exited_receiver.recv() => Some(status),
         startup_result = ghci.initialize(&mut log, [LifecycleEvent::Startup(hooks::When::After)]) => {
             // Only reachable if ghci starts successfully (startup_result = Ok) or if
             // initialization fails for a non-EOF reason (e.g., a lifecycle hook error).
-            startup_result?;
-            None
+            match startup_result {
+                Ok(()) => {},
+                Err(err) => {
+                    let is_broken_pipe = err.chain().any(|e| {
+                        e.downcast_ref::<std::io::Error>()
+                            .is_some_and(|io| io.kind() == std::io::ErrorKind::BrokenPipe)
+                    });
+                    if is_broken_pipe {
+                        tracing::debug!("ghci stdin closed during startup (broken pipe): {err}");
+                    } else {
+                        return Err(err);
+                    }
+                }
+            }
         }
     };
+    let startup_exit: Option<ExitStatus> = exited_receiver.try_recv().ok();
     if let Some(status) = startup_exit {
         match wait_and_restart(
             &mut handle,

--- a/src/incremental_reader.rs
+++ b/src/incremental_reader.rs
@@ -88,9 +88,14 @@ where
         }
     }
 
-    /// Examines the internal buffer and reads at most once from the underlying reader. If a line
-    /// beginning with one of the `end_marker` patterns is seen, the lines before the marker are
-    /// returned. Otherwise, nothing is returned.
+    /// Examines the internal buffer and reads at most once from the underlying reader.
+    ///
+    /// If a line beginning with one of the `end_marker` patterns is seen, the lines before the
+    /// marker are returned.
+    ///
+    /// If the stream EOFs, all the data read is returned immediately.
+    ///
+    /// Otherwise, nothing is returned.
     async fn try_read_until(&mut self, opts: &mut ReadOpts<'_>) -> eyre::Result<Option<String>> {
         self.drain_pending(opts.writing).await?;
 
@@ -101,13 +106,11 @@ where
 
         match self.reader.read(opts.buffer).await {
             Ok(0) => {
-                // EOF — the process closed its stdout. Yield to allow other tasks
-                // (e.g., GhciProcess reporting the exit) to run before we loop again.
-                // This prevents a busy-loop and ensures that a tokio::select! containing
-                // this future will check its other arms (like exited_receiver.recv()) on
-                // the next poll.
-                tokio::task::yield_now().await;
-                Ok(None)
+                // EOF — the process closed its stdout.
+                //
+                // Return all the data we have.
+                let lines = self.take_lines(opts.writing).await?;
+                Ok(Some(lines))
             }
             Ok(n) => {
                 let decoded = self.decode(&opts.buffer[..n]);


### PR DESCRIPTION
Previously, the `tokio::select!` in `ghci::manager` would see that the `ghci` process had exited and would cancel the `ghci.initialize()` job as a result.

However, we actually want the `ghci.initialize()` job to complete (even if it errors out), because it will read the `ghci` output and write (e.g.) compilation errors to the error log.

Usually, `ghci.initialize()` will fail with a `BrokenPipe` IO error in this case (trying to write to GHCi's stdin after the process has exited), so we catch those errors explicitly and ignore them (needs DUX-5106).