### PR TITLE
DUX-5111 Remove GHC 9.4 support

### DIFF
--- a/test-harness/src/ghc_version.rs
+++ b/test-harness/src/ghc_version.rs
@@ -33,8 +33,6 @@ impl Display for FullGhcVersion {
 /// Variants of this enum will correspond to `ghcVersions` in `../../flake.nix`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum GhcVersion {
-    /// GHC 9.4
-    Ghc94,
     /// GHC 9.6
     Ghc96,
     /// GHC 9.8
@@ -61,14 +59,12 @@ impl FromStr for GhcVersion {
         let (_full, [major, minor, _patch]) = captures.extract();
 
         match (major, minor) {
-            ("9", "4") => Ok(Self::Ghc94),
             ("9", "6") => Ok(Self::Ghc96),
             ("9", "8") => Ok(Self::Ghc98),
             ("9", "10") => Ok(Self::Ghc910),
             ("9", "12") => Ok(Self::Ghc912),
             (_, _) => Err(eyre!(
                 "Only the following GHC versions are supported:\n\
-                - 9.4\n\
                 - 9.6\n\
                 - 9.8\n\
                 - 9.10\n\
@@ -84,26 +80,26 @@ mod tests {
 
     #[test]
     fn test_parse_ghc_version() {
-        assert_eq!("9.4.8".parse::<GhcVersion>().unwrap(), GhcVersion::Ghc94);
         assert_eq!("9.6.1".parse::<GhcVersion>().unwrap(), GhcVersion::Ghc96);
         assert_eq!("9.10.1".parse::<GhcVersion>().unwrap(), GhcVersion::Ghc910);
         assert_eq!("9.12.1".parse::<GhcVersion>().unwrap(), GhcVersion::Ghc910);
 
-        "9.6.1rc1"
+        let _ = "9.6.1rc1"
             .parse::<GhcVersion>()
             .expect_err("Extra information at the end");
-        "9.6.1-pre"
+        let _ = "9.6.1-pre"
             .parse::<GhcVersion>()
             .expect_err("Extra information at the end");
-        "9.6.1.2"
+        let _ = "9.6.1.2"
             .parse::<GhcVersion>()
             .expect_err("Extra version component");
-        "9.6"
+        let _ = "9.6"
             .parse::<GhcVersion>()
             .expect_err("Missing patch version component");
-        "9".parse::<GhcVersion>()
+        let _ = "9"
+            .parse::<GhcVersion>()
             .expect_err("Missing patch and minor version components");
-        "a.b.c"
+        let _ = "a.b.c"
             .parse::<GhcVersion>()
             .expect_err("Non-numeric components");
     }

--- a/tests/error_log.rs
+++ b/tests/error_log.rs
@@ -3,7 +3,6 @@ use indoc::indoc;
 
 use test_harness::test;
 use test_harness::BaseMatcher;
-use test_harness::GhcVersion::*;
 use test_harness::GhciWatchBuilder;
 
 /// Test that `ghciwatch --errors ...` can write the error log.
@@ -84,19 +83,7 @@ async fn can_write_error_log_compilation_errors() {
         .await
         .expect("ghciwatch writes ghcid.txt");
 
-    let expected = match session.ghc_version() {
-        Ghc94 => expect![[r#"
-            src/My/Module.hs:3:11: error:
-                * Couldn't match type `[Char]' with `()'
-                  Expected: ()
-                    Actual: String
-                * In the expression: "Uh oh!"
-                  In an equation for `myIdent': myIdent = "Uh oh!"
-              |
-            3 | myIdent = "Uh oh!"
-              |           ^^^^^^^^
-        "#]],
-        Ghc96 | Ghc98 | Ghc910 | Ghc912 => expect![[r#"
+    expect![[r#"
             src/My/Module.hs:3:11: error: [GHC-83865]
                 * Couldn't match type `[Char]' with `()'
                   Expected: ()
@@ -106,10 +93,8 @@ async fn can_write_error_log_compilation_errors() {
               |
             3 | myIdent = "Uh oh!"
               |           ^^^^^^^^
-        "#]],
-    };
-
-    expected.assert_eq(&error_contents);
+        "#]]
+    .assert_eq(&error_contents);
 
     session
         .fs()


### PR DESCRIPTION
We don't test with GHC 9.4! But I never removed support for it from the test suite. Oops!