### PR TITLE
DUX-5115 Add startup failure error log test

### DIFF
--- a/src/ghci/manager.rs
+++ b/src/ghci/manager.rs
@@ -81,20 +81,7 @@ pub async fn run_ghci(
         startup_result = ghci.initialize(&mut log, [LifecycleEvent::Startup(hooks::When::After)]) => {
             // Only reachable if ghci starts successfully (startup_result = Ok) or if
             // initialization fails for a non-EOF reason (e.g., a lifecycle hook error).
-            match startup_result {
-                Ok(()) => {},
-                Err(err) => {
-                    let is_broken_pipe = err.chain().any(|e| {
-                        e.downcast_ref::<std::io::Error>()
-                            .is_some_and(|io| io.kind() == std::io::ErrorKind::BrokenPipe)
-                    });
-                    if is_broken_pipe {
-                        tracing::debug!("ghci stdin closed during startup (broken pipe): {err}");
-                    } else {
-                        return Err(err);
-                    }
-                }
-            }
+            handle_broken_pipe(startup_result)?;
         }
     };
     let startup_exit: Option<ExitStatus> = exited_receiver.try_recv().ok();
@@ -500,7 +487,7 @@ impl RestartStrategy<'_> {
     }
 
     async fn restart(&mut self) -> eyre::Result<()> {
-        match self {
+        handle_broken_pipe(match self {
             Self::Startup(ghci) => ghci
                 .startup_restart()
                 .await
@@ -511,7 +498,7 @@ impl RestartStrategy<'_> {
                 .startup_restart()
                 .await
                 .wrap_err("Failed to restart ghci after unexpected exit"),
-        }
+        })
     }
 }
 
@@ -571,6 +558,24 @@ async fn wait_and_restart(
             result = strategy.restart() => {
                 result?;
                 return Ok(RetryResult::Restarted);
+            }
+        }
+    }
+}
+
+fn handle_broken_pipe(result: eyre::Result<()>) -> eyre::Result<()> {
+    match result {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            let is_broken_pipe = err.chain().any(|e| {
+                e.downcast_ref::<std::io::Error>()
+                    .is_some_and(|io| io.kind() == std::io::ErrorKind::BrokenPipe)
+            });
+            if is_broken_pipe {
+                tracing::debug!("ignoring broken pipe error: {err}");
+                Ok(())
+            } else {
+                Err(err)
             }
         }
     }

--- a/tests/error_log.rs
+++ b/tests/error_log.rs
@@ -3,6 +3,7 @@ use indoc::indoc;
 
 use test_harness::test;
 use test_harness::BaseMatcher;
+use test_harness::Fs;
 use test_harness::GhcVersion;
 use test_harness::GhciWatchBuilder;
 
@@ -204,6 +205,64 @@ async fn can_adjust_error_log_paths() {
         "#]],
         GhcVersion::Ghc912 => expect![[r#"
             simple-dep/src/SimpleDep.hs:4:20: error: [GHC-21231]
+                lexical error at character '\n'
+              |
+            4 | depFunc = putStrLn "depFunc
+              |                    ^^^^^^^^
+        "#]],
+    };
+
+    expected.assert_eq(&error_contents);
+}
+
+#[test]
+async fn error_log_startup_failure() {
+    let error_path = "ghcid.txt";
+    let mut session = GhciWatchBuilder::new("tests/data/with-dep")
+        .with_args(["--errors", error_path])
+        .before_start(move |path| {
+            // A version of SimpleDep.hs with an unclosed string literal — cabal will refuse to build it.
+            async move {
+                Fs::new()
+                    .replace(
+                        path.join("simple-dep/src/SimpleDep.hs"),
+                        "\"depFunc\"",
+                        "\"depFunc",
+                    )
+                    .await
+            }
+        })
+        .start()
+        .await
+        .expect("ghciwatch starts");
+    let error_path = session.path(error_path);
+
+    // First startup fails because simple-dep won't compile.
+    // NB: This message means that ghciwatch didn't crash!
+    session
+        .wait_for_startup_log("ghci exited during startup")
+        .await
+        .expect("ghciwatch detects first startup failure");
+
+    let error_contents = session
+        .fs()
+        .read(&error_path)
+        .await
+        .expect("ghciwatch writes ghcid.txt");
+
+    // We don't have access to the package's directory here so we can't fix these paths!
+    // These _should_ be like `simple-dep/src/SimpleDep.hs` but GHC doesn't emit them relative to
+    // the invocation so users are just Fucked.
+    let expected = match session.ghc_version() {
+        GhcVersion::Ghc96 | GhcVersion::Ghc98 | GhcVersion::Ghc910 => expect![[r#"
+            src/SimpleDep.hs:4:28: error: [GHC-21231]
+                lexical error in string/character literal at character '\n'
+              |
+            4 | depFunc = putStrLn "depFunc
+              |                            ^
+        "#]],
+        GhcVersion::Ghc912 => expect![[r#"
+            src/SimpleDep.hs:4:20: error: [GHC-21231]
                 lexical error at character '\n'
               |
             4 | depFunc = putStrLn "depFunc


### PR DESCRIPTION
#444 got auto-merged a bit early, oops!

I can confirm that if you comment out the change in #444 then a bunch of stuff fails:

```
     Summary [  83.049s] 239 tests run: 227 passed (1 leaky), 12 failed, 0 skipped
        FAIL [  36.712s] ghciwatch::error_log error_log_startup_failure_9102
        FAIL [  24.564s] ghciwatch::error_log error_log_startup_failure_9122
        FAIL [  22.095s] ghciwatch::error_log error_log_startup_failure_967
        FAIL [  33.764s] ghciwatch::error_log error_log_startup_failure_984
        FAIL [  22.941s] ghciwatch::shutdown handles_repeated_startup_failures_9102
        FAIL [  24.139s] ghciwatch::shutdown handles_repeated_startup_failures_9122
        FAIL [  25.440s] ghciwatch::shutdown handles_repeated_startup_failures_967
        FAIL [  27.936s] ghciwatch::shutdown handles_repeated_startup_failures_984
        FAIL [  27.663s] ghciwatch::shutdown handles_repeated_startup_failures_before_restart_ghci_hook_9102
        FAIL [  25.208s] ghciwatch::shutdown handles_repeated_startup_failures_before_restart_ghci_hook_9122
        FAIL [  22.660s] ghciwatch::shutdown handles_repeated_startup_failures_before_restart_ghci_hook_967
        FAIL [  31.145s] ghciwatch::shutdown handles_repeated_startup_failures_before_restart_ghci_hook_984
```