### PR TITLE
DUX-5327 Add `--extra-module-search-path`

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -78,6 +78,15 @@ Evaluate Haskell code in comments.
 This parses line commands starting with `-- $>` or multiline commands delimited by `{- $>` and `<$ -}` and evaluates them after reloads.
 
 </dd>
+<dt><a id="--extra-module-search-path" href="#--extra-module-search-path"><code>--extra-module-search-path &lt;PATH&gt;</code></a></dt><dd>
+
+An extra directory for converting module paths to module names and vice versa, in addition to the module import search paths from GHCi's `:show paths` output.
+
+In some setups (like multi-package projects), GHCi's search paths don't include the source directories of all loaded packages, so converting between source paths and module names can fail. Use this option to supplement the search paths with extra directories, like `my-package/src`.
+
+Can be given multiple times.
+
+</dd>
 <dt><a id="--clear" href="#--clear"><code>--clear</code></a></dt><dd>
 
 Clear the screen before reloads and restarts

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,6 +61,18 @@ pub struct Opts {
     #[arg(long, alias = "allow-eval")]
     pub enable_eval: bool,
 
+    /// An extra directory for converting module paths to module names and vice versa, in
+    /// addition to the module import search paths from GHCi's `:show paths` output.
+    ///
+    /// In some setups (like multi-package projects), GHCi's search paths don't include the
+    /// source directories of all loaded packages, so converting between source paths and module
+    /// names can fail. Use this option to supplement the search paths with extra directories,
+    /// like `my-package/src`.
+    ///
+    /// Can be given multiple times.
+    #[arg(long = "extra-module-search-path", value_name = "PATH")]
+    pub extra_module_search_paths: Vec<NormalPath>,
+
     /// Clear the screen before reloads and restarts.
     #[arg(long)]
     pub clear: bool,

--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -112,6 +112,9 @@ pub struct GhciOpts {
     pub error_path: Option<Utf8PathBuf>,
     /// Enable running eval commands in files.
     pub enable_eval: bool,
+    /// Extra directories to add to the module import search paths parsed from `:show paths`,
+    /// used for converting module paths to module names and vice versa.
+    pub extra_search_paths: Vec<Utf8PathBuf>,
     /// Lifecycle hooks, mostly `ghci` commands to run at certain points.
     pub hooks: HookOpts,
     /// Restart the `ghci` session when paths matching these globs are changed.
@@ -197,6 +200,11 @@ impl GhciOpts {
                 command,
                 error_path: opts.error_file.clone(),
                 enable_eval: opts.enable_eval,
+                extra_search_paths: opts
+                    .extra_module_search_paths
+                    .iter()
+                    .map(|path| path.absolute().to_owned())
+                    .collect(),
                 hooks: opts.hooks.clone(),
                 restart_globs: opts.watch.restart_globs()?,
                 reload_globs: opts.watch.reload_globs()?,
@@ -386,6 +394,7 @@ impl Ghci {
         });
         let classifier =
             FileClassifier::new(opts.restart_globs.clone(), opts.reload_globs.clone())?;
+        let extra_search_paths = opts.extra_search_paths.clone();
 
         Ok(Ghci {
             opts,
@@ -401,7 +410,7 @@ impl Ghci {
             eval_commands: Default::default(),
             search_paths: ShowPaths {
                 cwd: crate::current_dir_utf8()?,
-                search_paths: Default::default(),
+                search_paths: extra_search_paths,
             },
             command_handles,
             sync_nonce: 0,
@@ -648,6 +657,11 @@ impl Ghci {
     #[instrument(skip_all, level = "debug")]
     async fn refresh_paths(&mut self) -> eyre::Result<()> {
         self.search_paths = self.stdin.show_paths(&mut self.stdout).await?;
+        for path in &self.opts.extra_search_paths {
+            if !self.search_paths.search_paths.contains(path) {
+                self.search_paths.search_paths.push(path.clone());
+            }
+        }
         self.classifier.set_cwd(self.search_paths.cwd.clone());
         tracing::debug!(cwd = %self.search_paths.cwd, search_paths = ?self.search_paths.search_paths, "Parsed paths");
         Ok(())


### PR DESCRIPTION
Ghciwatch relies on GHCi's `:show paths` output to tell it where to search for modules (usually, in your `src` directory). This is needed to convert from modules names to source paths and vice versa, in particular for eval-comments (some GHCi commands only accept module names, so we need to go from file events and file paths to module names).

We're experimenting with [launching GHCi with Buck2 pointed at a synthesized source tree][1] of symlinks which combines sources from multiple Cabal packages into one unified tree, giving us fast reloads across packages without restarting ghciwatch.

The trouble with this is that the `:show paths` output is incorrect, pointing only at the synthesized source tree and the current working directory.

We _could_ give ghciwatch a number of paths to 'strip' when looking for sources:
- Tell ghciwatch about all of the 'actual' source roots in the filesystem.
- When ghciwatch is converting from file path to module path, it first strips any of those roots off the start of the file path.
- Then it looks under the `:show paths` roots for the path, finding the symlink back to the original path.

This is complex for little benefit. It seems to work just as well to tell ghciwatch to _pretend_ that all of the 'actual' source roots are source roots. So let's do that -- it's a simple flag to add a new path to an internal list 'as if' it was present in the `:show paths` output.

[1]: https://gerrit.oss.mercury.com/q/topic:%22ghci-global%22
