### PR TITLE
DUX-5330 eval: Only interpret modules once

### DIFF
--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -609,24 +609,30 @@ impl Ghci {
         // Might be more efficient to swap it out for a default, but then it gets trickier to
         // restore the old value when the function returns.
         for (path, commands) in self.eval_commands.clone() {
+            // If the `module` was already compiled, `ghci` may have loaded the interface file instead
+            // of the interpreted bytecode, giving us this error message when we attempt to
+            // load the top-level scope with `:module + *{module}`:
+            //
+            //     module 'Mercury.Typescript.Golden' is not interpreted
+            //
+            // We use `:add *{module}` to force interpreting the module. We do this here instead of in
+            // `add_module` to save time if eval commands aren't used (or aren't needed for a
+            // particular module).
+            tracing::info!("Loading {path} in interpreted mode for eval commands");
+            self.interpret_module(&path, log).await?;
+            let module = self.search_paths.path_to_module(&path)?;
+            self.stdin
+                .add_module_to_scope(&mut self.stdout, &module, log)
+                .await?;
             for command in commands {
-                // If the `module` was already compiled, `ghci` may have loaded the interface file instead
-                // of the interpreted bytecode, giving us this error message when we attempt to
-                // load the top-level scope with `:module + *{module}`:
-                //
-                //     module 'Mercury.Typescript.Golden' is not interpreted
-                //
-                // We use `:add *{module}` to force interpreting the module. We do this here instead of in
-                // `add_module` to save time if eval commands aren't used (or aren't needed for a
-                // particular module).
-                tracing::info!("Loading {path} in interpreted mode for eval commands");
-                self.interpret_module(&path, log).await?;
-                let module = self.search_paths.path_to_module(&path)?;
                 tracing::info!("Eval {path}:{command}");
                 self.stdin
-                    .eval(&mut self.stdout, &module, &command.command, log)
+                    .run_command(&mut self.stdout, &command.command, log)
                     .await?;
             }
+            self.stdin
+                .remove_module_from_scope(&mut self.stdout, &module, log)
+                .await?;
         }
 
         Ok(())

--- a/src/ghci/stdin.rs
+++ b/src/ghci/stdin.rs
@@ -161,23 +161,28 @@ impl GhciStdin {
             .await
     }
 
+    /// Add a module's top level identifiers to scope with `:module + *{module_name}`.
     #[instrument(skip(self, stdout), level = "debug")]
-    pub async fn eval(
+    pub async fn add_module_to_scope(
         &mut self,
         stdout: &mut GhciStdout,
         module_name: &str,
-        command: &GhciCommand,
         log: &mut CompilationLog,
     ) -> eyre::Result<()> {
         self.write_line(stdout, &format!(":module + *{module_name}\n"), log)
-            .await?;
+            .await
+    }
 
-        self.run_command(stdout, command, log).await?;
-
+    /// Remove a module's top level identifiers to scope with `:module - *{module_name}`.
+    #[instrument(skip(self, stdout), level = "debug")]
+    pub async fn remove_module_from_scope(
+        &mut self,
+        stdout: &mut GhciStdout,
+        module_name: &str,
+        log: &mut CompilationLog,
+    ) -> eyre::Result<()> {
         self.write_line(stdout, &format!(":module - *{module_name}\n"), log)
-            .await?;
-
-        Ok(())
+            .await
     }
 
     #[instrument(skip(self, stdout), level = "debug")]


### PR DESCRIPTION
When running eval comments, we `:add` the module to interpret it before every eval command, even if we're running multiple eval commands for the same module. Let's only add the module once, no matter how many commands there are.