### PR TITLE
DUX-5340 Fix broken pipe crash when ghci dies during a dispatched restart

### DIFF
--- a/src/ghci/manager.rs
+++ b/src/ghci/manager.rs
@@ -383,9 +383,33 @@ impl GhciManager {
                     continue;
                 }
                 ret = &mut task => {
-                    ret??;
-                    tracing::debug!("Finished dispatching ghci event");
-                    None
+                    match ret? {
+                        Ok(()) => {
+                            tracing::debug!("Finished dispatching ghci event");
+                            None
+                        }
+                        Err(err) if is_broken_pipe(&err) => {
+                            // ghci died during the dispatch and the death surfaced
+                            // inside the dispatch task itself as a broken pipe. The
+                            // exit status is guaranteed to arrive on the exit channel
+                            // (unless a shutdown wins the `select!` in
+                            // `GhciProcess::run` first), so wait for it and route
+                            // through the standard restart path.
+                            tracing::debug!("ghci exited while dispatching: {err}");
+                            tokio::select! {
+                                _ = handle.on_shutdown_requested() => {
+                                    // ghci is already dead; nothing to stop.
+                                    return Ok(HandleResult::Shutdown);
+                                }
+                                status = exited_receiver.recv() => match status {
+                                    Some(status) => Some(status),
+                                    // Channel closed -- shutdown in progress.
+                                    None => return Ok(HandleResult::Shutdown),
+                                },
+                            }
+                        }
+                        Err(err) => return Err(err),
+                    }
                 }
             };
         };


### PR DESCRIPTION
Saw test failures when integrating 1.4.0. The perils of only running tests once in CI!!

> DUX-5329 (#451) fixed the broken-pipe-vs-exit-channel race in run_ghci's startup path and in wait_and_restart, but missed the third site: the dispatch task in GhciManager::handle_event. When a file matching --restart-glob triggers a restart and the new ghci fails to build, the broken pipe propagates out of reload() and `ret??` crashes the whole run_ghci task with `Tasks failed: run_ghci: Broken pipe (os error 32)` instead of logging "ghci exited unexpectedly" -- unless the exit status happens to land on the channel first and win the (unbiased) select!, which made the handles_unexpected_exit_during_dispatch tests flaky.
>
> Give the dispatch arm the same treatment as the other two sites: a broken pipe from the dispatch task means ghci died and the exit status is guaranteed to arrive on the exit channel, so await it (bailing out on shutdown) and route through the standard wait-and-restart path.