### PR TITLE
DUX-5350 Don't eval modules with no eval commands

### DIFF
--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -618,6 +618,11 @@ impl Ghci {
         // Might be more efficient to swap it out for a default, but then it gets trickier to
         // restore the old value when the function returns.
         for (path, commands) in self.eval_commands.clone() {
+            // If we don't have any eval commands for this path, do nothing.
+            if commands.is_empty() {
+                continue;
+            }
+
             // If the `module` was already compiled, `ghci` may have loaded the interface file instead
             // of the interpreted bytecode, giving us this error message when we attempt to
             // load the top-level scope with `:module + *{module}`:


### PR DESCRIPTION
In #454 I restructured the eval command logic.

Before, the loop looked like this:

```rust
for (path, commands) in eval_commands_by_path {
  for command in commands {
    do_eval_command(command);
  }
}
```

After, I pulled some logic out of the inner loop:

```rust
for (path, commands) in eval_commands_by_path {
  do_common_logic(path);
  for command in commands {
    do_eval_command(command);
  }
  finish_common_logic(path);
}
```

But sometimes `commands` was empty, doing unnecessary work in the best case and attempting to eval non-Haskell in the worst case!

Let's skip empty entries.

- [ ] Updated the user manual in `docs/`.
- [ ] Added integration / regression tests in `tests/`.
