### PR TITLE
DUX-5352 eval: Skip parsing commands in non-Haskell files

### DIFF
--- a/src/ghci/mod.rs
+++ b/src/ghci/mod.rs
@@ -64,6 +64,7 @@ pub use compilation_log::CompilationLog;
 mod writer;
 use crate::buffers::GHCI_BUFFER_CAPACITY;
 pub use crate::ghci::writer::GhciWriter;
+use crate::haskell_source_file::is_haskell_source_file;
 
 mod progress_writer;
 
@@ -683,6 +684,7 @@ impl Ghci {
         let mut eval_commands = BTreeMap::new();
 
         for target in self.targets.iter() {
+            // Note: Loaded targets are always Haskell modules.
             let commands = Self::parse_eval_commands(target.path()).await?;
             if !commands.is_empty() {
                 eval_commands.insert(target.path().clone(), commands);
@@ -705,6 +707,27 @@ impl Ghci {
 
         for path in paths {
             let path = path.borrow();
+
+            // To actually _execute_ eval commands with the proper bindings in scope, we need to be
+            // able to evaluate (interpret) a file, which requires we know its module _name_
+            // (because `:module + *MODULE_NAME` only supports module names and not source paths).
+            //
+            // We get _all_ file events in this loop, not just Haskell source files, so let's guard
+            // adding an entry to the `eval_commands` map by making sure we can convert the path to
+            // a module name.
+            if self.search_paths.path_to_module(path).is_err() {
+                if is_haskell_source_file(path) {
+                    // If the path is a Haskell source file (ends with `.hs` or similar), we should
+                    // warn the user directly. Otherwise, it's probably a `.persistentmodels` or
+                    // something and the user (probably!) won't expect eval commands to be evaluated
+                    // in it.
+                    tracing::warn!(%path, "Could not determine module path, skipping parsing eval commands");
+                } else {
+                    tracing::debug!(%path, "Could not determine module path, skipping parsing eval commands");
+                }
+                continue;
+            }
+
             let commands = Self::parse_eval_commands(path).await?;
             self.eval_commands.insert(path.clone(), commands);
         }

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -250,3 +250,65 @@ async fn can_eval_commands_twice() {
         .await
         .expect("ghciwatch evals commands");
 }
+
+/// Test that `ghciwatch` can handle file events (e.g. `--reload-glob`s) for non-Haskell files, and
+/// that we don't try to evaluate/interpret these!
+#[test]
+async fn eval_can_handle_non_haskell_files() {
+    let relative_model_path = "models/doggy.persistentmodels";
+    let cmd = "-- $> example ++ example";
+    let mut session = GhciWatchBuilder::new("tests/data/simple")
+        .with_args([
+            "--enable-eval",
+            "--watch",
+            "models",
+            "--reload-glob",
+            "*.persistentmodels",
+        ])
+        .before_start(move |path| async move {
+            let fs = Fs::new();
+
+            fs.create_dir(path.join("models")).await?;
+
+            fs.write(path.join(relative_model_path), format!("\n{cmd}\n"))
+                .await?;
+
+            Ok(())
+        })
+        .start()
+        .await
+        .expect("ghciwatch starts");
+    let model_path = session.path(relative_model_path);
+
+    session
+        .wait_until_ready()
+        .await
+        .expect("ghciwatch didn't start in time");
+
+    let reload_no_eval_matcher = BaseMatcher::reload_completes()
+        .and(
+            BaseMatcher::span_close()
+                .in_leaf_spans(["eval"])
+                .in_module("ghciwatch::ghci"),
+        )
+        .but_not(BaseMatcher::message(&format!(
+            "Loading {} in interpreted mode for eval commands",
+            regex::escape(relative_model_path)
+        )));
+
+    // Make sure we can reload.
+    session.clear_events();
+    session.fs().touch(&model_path).await.unwrap();
+    session
+        .assert_logged_or_wait(reload_no_eval_matcher.clone())
+        .await
+        .expect("ghciwatch handles non-Haskell files in eval mode");
+
+    // Make sure we can reload _again_ (i.e. ghciwatch didn't crash).
+    session.clear_events();
+    session.fs().touch(&model_path).await.unwrap();
+    session
+        .assert_logged_or_wait(reload_no_eval_matcher)
+        .await
+        .expect("ghciwatch handles non-Haskell files in eval mode");
+}


### PR DESCRIPTION
To actually _execute_ eval commands with the proper bindings in scope, we need to be able to evaluate (interpret) a file, which requires we know its module _name_ (because `:module + *MODULE_NAME` only supports module names and not source paths).

Let's guard adding an entry to the `eval_commands` map by making sure we can convert the path to a module name.

See also: #458, #454.

- [ ] Updated the user manual in `docs/`.
- [x] Added integration / regression tests in `tests/`.
